### PR TITLE
Updates gradle for AndroidStudio3.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /build
 /captures
 .externalNativeBuild
+.idea

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,18 +2,18 @@ apply plugin: 'com.android.application'
 apply plugin: 'realm-android'
 
 ext {
-    supportLibraryVersion = '25.3.1'
+    supportLibraryVersion = '26.1.0'
 }
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 26
     buildToolsVersion '26.0.2'
     defaultConfig {
         applicationId "crux.bphc.cms"
-        minSdkVersion 21
-        targetSdkVersion 25
-        versionCode 4
-        versionName "1.3"
+        minSdkVersion 16
+        targetSdkVersion 26
+        versionCode 3
+        versionName "1.2"
         vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
@@ -23,23 +23,33 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    compile fileTree(include: ['*.jar'], dir: 'libs')
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile "com.android.support:customtabs:$supportLibraryVersion"
-    compile "com.android.support:appcompat-v7:$supportLibraryVersion"
-    compile "com.android.support:design:$supportLibraryVersion"
-    compile "com.android.support:cardview-v7:$supportLibraryVersion"
-    compile "com.android.support:support-v4:$supportLibraryVersion"
-    compile 'com.squareup.retrofit2:retrofit:2.1.0'
-    compile 'com.squareup.retrofit2:converter-gson:2.1.0'
-    compile 'com.squareup.picasso:picasso:2.5.2'
-    compile "com.android.support:support-v4:$supportLibraryVersion"
-    compile "com.android.support:support-vector-drawable:$supportLibraryVersion"
-    compile 'com.firebase:firebase-jobdispatcher:0.7.0'
-    testCompile 'junit:junit:4.12'
+
+    testImplementation 'junit:junit:4.12'
+    implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
+    implementation "com.android.support:support-v4:$supportLibraryVersion"
+    implementation "com.android.support:design:$supportLibraryVersion"
+    implementation "com.android.support:customtabs:$supportLibraryVersion"
+    implementation "com.android.support:cardview-v7:$supportLibraryVersion"
+    implementation "com.android.support:support-vector-drawable:$supportLibraryVersion"
+    // Network requests library
+    implementation 'com.squareup.retrofit2:retrofit:2.2.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.2.0'
+    implementation 'com.squareup.okhttp3:logging-interceptor:3.8.0'
+    // for logging
+    // Image downloading and caching library
+    implementation 'com.squareup.picasso:picasso:2.5.2'
+    // Resources dependency injection
+    implementation 'com.jakewharton:butterknife:8.8.1'
+    annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.1'
 }

--- a/app/src/main/java/app/MyApplication.java
+++ b/app/src/main/java/app/MyApplication.java
@@ -24,6 +24,12 @@ public class MyApplication extends Application {
         realm = Realm.getInstance(config);
     }
 
+    @Override
+    public void onLowMemory() {
+        super.onLowMemory();
+        if (!realm.isClosed()) realm.close();
+    }
+
     public Realm getRealmInstance() {
         return realm;
     }

--- a/app/src/main/java/crux/bphc/cms/fragments/CourseSectionFragment.java
+++ b/app/src/main/java/crux/bphc/cms/fragments/CourseSectionFragment.java
@@ -42,7 +42,7 @@ import static app.Constants.API_URL;
 import static helper.MyFileManager.DATA_DOWNLOADED;
 
 /**
- * Created by siddhant on 12/21/16.
+ * Created by SKrPl on 12/21/16.
  */
 
 public class CourseSectionFragment extends Fragment {

--- a/app/src/main/java/helper/APIClient.java
+++ b/app/src/main/java/helper/APIClient.java
@@ -1,0 +1,40 @@
+package helper;
+
+import app.Constants;
+import crux.bphc.cms.BuildConfig;
+import okhttp3.OkHttpClient;
+import okhttp3.logging.HttpLoggingInterceptor;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+
+/**
+ * Created by SKrPl on 11/23/17.
+ */
+
+public class APIClient {
+
+    private static Retrofit retrofit = null;
+
+    private static HttpLoggingInterceptor interceptor =
+            new HttpLoggingInterceptor();
+    private static OkHttpClient.Builder builder = new OkHttpClient.Builder();
+
+    private APIClient() {
+    }
+
+    public static Retrofit getRetrofitInstance() {
+        if (retrofit == null) {
+            interceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
+            if (BuildConfig.DEBUG) {
+                builder.addInterceptor(interceptor);
+            }
+
+            retrofit = new Retrofit.Builder()
+                    .addConverterFactory(GsonConverterFactory.create())
+                    .baseUrl(Constants.API_URL)
+                    .client(builder.build())
+                    .build();
+        }
+        return retrofit;
+    }
+}

--- a/app/src/main/java/helper/MoodleServices.java
+++ b/app/src/main/java/helper/MoodleServices.java
@@ -6,7 +6,6 @@ import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.http.GET;
 import retrofit2.http.Query;
-import set.Course;
 import set.CourseSection;
 import set.enrol.SelfEnrol;
 import set.search.CourseSearch;

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath "io.realm:realm-gradle-plugin:2.2.1"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -15,6 +16,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-#Wed Nov 22 00:41:10 IST 2017
+#Tue Nov 21 23:18:39 IST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
1. Replaces "compile" with "implementation"
2. Adds Java 8 support
3. Adds ButterKnife library for resources injection
4. Adds OkHttp3-Logging Interceptor for easy debugging of network calls.
5. Adds a APIClient class for centralizing retrofit instance generation.