### PR TITLE
Fixes #57: File doesn't open if file of same name is downloaded in another course

### DIFF
--- a/app/src/main/java/helper/ModulesAdapter.java
+++ b/app/src/main/java/helper/ModulesAdapter.java
@@ -200,7 +200,7 @@ public class ModulesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                 List<Content> contents = module.getContents();
                 downloaded = 1;
                 for (Content content : contents) {
-                    if (!mFileManager.searchFile(content.getFilename())) {
+                    if (!mFileManager.searchFile(courseName, content.getFilename())) {
                         downloaded = 0;
                         break;
                     }

--- a/app/src/main/java/helper/MyFileManager.java
+++ b/app/src/main/java/helper/MyFileManager.java
@@ -164,6 +164,21 @@ public class MyFileManager {
         return false;
     }
 
+    public boolean searchFile(String courseName, String fileName) {
+        //if courseName is empty check sb folders
+        if (fileList == null) {
+            reloadFileList(courseName);
+            if (fileList.size() == 0) {
+                return false;
+            }
+        }
+        if (fileList.contains(fileName)) {
+            Log.d("File found:", fileName);
+            return true;
+        }
+        return false;
+    }
+
     public void openFile(String filename, String courseName) {
         File file = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).getPath(),
                 getFilePath(courseName, filename));
@@ -221,6 +236,15 @@ public class MyFileManager {
             }
         }
 
+    }
+
+    public void reloadFileList(String coureName){
+        fileList = new ArrayList<>();
+        File courseDirec = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).getPath()
+                + File.separator + CMS + File.separator + coureName);
+        if (courseDirec.isDirectory()) {
+            fileList.addAll(Arrays.asList(courseDirec.list()));
+        }
     }
 
     public boolean onClickAction(Module module, String courseName) {


### PR DESCRIPTION
The ModuleAdapter calls searchFile which searches the files in the entire CMS directory. It is now modified to search in the specific course.