### PR TITLE
Fixes #68: CMS API url changed

### DIFF
--- a/app/src/main/java/app/Constants.java
+++ b/app/src/main/java/app/Constants.java
@@ -13,7 +13,7 @@ public class Constants {
     public static final String GITHUB_URL = "https://github.com/CRUx-BPHC/CMS-Android/";
     public static final String GITHUB_URL_ISSUE = GITHUB_URL + "issues/";
     //"https://goo.gl/forms/wKCukHQTCDCp7HsG3";//GITHUB_URL + "issues/";
-    public static String API_URL = "http://id.bits-hyderabad.ac.in/moodle/";
+    public static String API_URL = "http://td.bits-hyderabad.ac.in/moodle/";
     public static String LOGIN_URL = API_URL + "login/index.php";
     public static String COURSE_URL = API_URL + "course/view.php";
     public static String TOKEN;


### PR DESCRIPTION
The `API_URL` in the url field is changed

References issue #68 