### PR TITLE
Support showing individual notifs for lower APIs

### DIFF
--- a/app/src/main/java/crux/bphc/cms/MainActivity.java
+++ b/app/src/main/java/crux/bphc/cms/MainActivity.java
@@ -37,8 +37,8 @@ import helper.UserAccount;
 import helper.UserUtils;
 
 import static app.Constants.API_URL;
-import static crux.bphc.cms.service.NotificationService.NOTIFICATION_CHANNEL_SERVICE;
 import static crux.bphc.cms.service.NotificationService.NOTIFICATION_CHANNEL_UPDATES;
+import static crux.bphc.cms.service.NotificationService.NOTIFICATION_CHANNEL_UPDATES_BUNDLE;
 
 public class MainActivity extends AppCompatActivity
         implements NavigationView.OnNavigationItemSelectedListener {
@@ -94,17 +94,18 @@ public class MainActivity extends AppCompatActivity
     // Create channels for devices running Oreo and above; Can be safely called even if channel exists
     void createNotificationChannels() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            // Create the "Background Service" channel, which has low importance
-            NotificationChannel service = new NotificationChannel(NOTIFICATION_CHANNEL_SERVICE,
-                    "Background Service",
-                    NotificationManager.IMPORTANCE_LOW);
-            service.setDescription("A low priority channel that informs the user when data is being synced.");
+            // Create the "Updates Bundle" channel, which is channel for summary notifications that bundles thr
+            // individual notifications
+            NotificationChannel service = new NotificationChannel(NOTIFICATION_CHANNEL_UPDATES_BUNDLE,
+                    "New Content Bundle",
+                    NotificationManager.IMPORTANCE_DEFAULT);
+            service.setDescription("A default priority channel that bundles all the notifications");
 
-            // Create the "Updates" channel which has the default importance level
+            // Create the "Updates" channel which has the low importance level
             NotificationChannel updates = new NotificationChannel(NOTIFICATION_CHANNEL_UPDATES,
                     "New Content",
-                    NotificationManager.IMPORTANCE_DEFAULT);
-            updates.setDescription("Primary channel that relays all content updates.");
+                    NotificationManager.IMPORTANCE_LOW);
+            updates.setDescription("All low importance channel that relays all the updates.");
 
             NotificationManager nm = getSystemService(NotificationManager.class);
             // create both channels

--- a/app/src/main/java/crux/bphc/cms/service/NotificationService.java
+++ b/app/src/main/java/crux/bphc/cms/service/NotificationService.java
@@ -37,7 +37,7 @@ public class NotificationService extends JobService {
     UserAccount userAccount;
     NotificationManager mNotifyMgr;
 
-    public static final String NOTIFICATION_CHANNEL_SERVICE = "channel_service";
+    public static final String NOTIFICATION_CHANNEL_UPDATES_BUNDLE = "channel_content_updates_bundle";
     public static final String NOTIFICATION_CHANNEL_UPDATES = "channel_content_updates";
 
     public static final int CMS_JOB_ID = 0;
@@ -197,13 +197,14 @@ public class NotificationService extends JobService {
             intent.putExtra("path", Uri.parse(Constants.getCourseURL(notificationSet.getCourseID())));
             PendingIntent pendingIntent = PendingIntent.getActivity(this, (int) System.currentTimeMillis(), intent, PendingIntent.FLAG_UPDATE_CURRENT);
 
-            NotificationCompat.Builder groupBuilder = new NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_UPDATES)
+            NotificationCompat.Builder groupBuilder = new NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_UPDATES_BUNDLE)
                     .setSmallIcon(R.mipmap.ic_launcher)
                     .setGroup(notificationSet.getGroupKey())
                     .setGroupSummary(true)
                     .setAutoCancel(true)
                     .setContentIntent(pendingIntent)
-                    .setPriority(PRIORITY_DEFAULT);
+                    .setPriority(PRIORITY_DEFAULT)
+                    .setOnlyAlertOnce(true);
 
             // channel ID is ignored for below Oreo
             NotificationCompat.Builder mBuilder =
@@ -217,8 +218,10 @@ public class NotificationService extends JobService {
                             .setContentIntent(pendingIntent)
                             .setPriority(NotificationCompat.PRIORITY_DEFAULT);
 
+            // Notify the summary notification for post nougat devices only
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+                mNotifyMgr.notify(notificationSet.getCourseID(), groupBuilder.build() );
 
-            mNotifyMgr.notify(notificationSet.getCourseID(), groupBuilder.build() );
             mNotifyMgr.notify(notificationSet.getModId(), mBuilder.build());
         }
     }

--- a/app/src/main/java/helper/ModulesAdapter.java
+++ b/app/src/main/java/helper/ModulesAdapter.java
@@ -165,6 +165,7 @@ public class ModulesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                             switch (i) {
                                 case 0:
                                     mFileManager.downloadFile(module.getContents().get(0), module, courseName);
+                                    break;
                                 case 1:
                                     markAsReadandUnread(module,position,true);
                             }


### PR DESCRIPTION
Changes made in the PR:
1. Added a condition that shows the summary notifications for post nougat devices. Earlier the summary notification in pre nougat devices showed a blank notification. This change ensures that they show only the individual notifications
2. Assigned a new channel for the bundle notifications and set it's importance to default and changed the individual updates channel's priority to low. This ensures that a single sound is a made for each bundle i.e each course
3. Added a break statement in one of the switch statements in ModulesAdapter