### PR TITLE
Change notifications title and add summary

### DIFF
--- a/app/src/main/java/crux/bphc/cms/service/NotificationService.java
+++ b/app/src/main/java/crux/bphc/cms/service/NotificationService.java
@@ -185,7 +185,7 @@ public class NotificationService extends JobService {
 
     private void createNotifSectionAdded(CourseSection section, Course course) {
         for (Module module : section.getModules()) {
-            createNotifModuleAdded(new NotificationSet(course, module));
+            createNotifModuleAdded(new NotificationSet(course, section ,module));
         }
     }
 
@@ -200,6 +200,10 @@ public class NotificationService extends JobService {
 
             NotificationCompat.Builder groupBuilder = new NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_UPDATES_BUNDLE)
                     .setSmallIcon(R.mipmap.ic_launcher)
+                    .setContentText(notificationSet.getCourseName())
+                    .setStyle(new NotificationCompat.InboxStyle()
+                                    .setBigContentTitle(notificationSet.getCourseName())
+                                    .setSummaryText(notificationSet.getCourseName()))
                     .setGroup(notificationSet.getGroupKey())
                     .setGroupSummary(true)
                     .setAutoCancel(true)
@@ -211,17 +215,26 @@ public class NotificationService extends JobService {
             NotificationCompat.Builder mBuilder =
                     new NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_UPDATES)
                             .setSmallIcon(R.mipmap.ic_launcher)
-                            .setContentTitle(parseHtml(notificationSet.getTitle()))
-                            .setContentText(parseHtml(notificationSet.getContentText()))
                             .setGroup(notificationSet.getGroupKey())
                             .setGroupSummary(false)
                             .setAutoCancel(true)
                             .setContentIntent(pendingIntent)
                             .setPriority(NotificationCompat.PRIORITY_DEFAULT);
 
-            // Notify the summary notification for post nougat devices only
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                mBuilder.setContentTitle(parseHtml(notificationSet.getSectionName()))
+                        .setContentText(parseHtml(notificationSet.getContentText()))
+                        .setStyle( new NotificationCompat.InboxStyle()
+                                .setSummaryText(notificationSet.getCourseName())
+                                .addLine(notificationSet.getContentText()));
+                // Notify the summary notification for post nougat devices only
                 mNotifyMgr.notify(notificationSet.getCourseID(), groupBuilder.build() );
+            } else {
+                mBuilder.setContentTitle(parseHtml(notificationSet.getCourseName()))
+                        .setContentText(parseHtml(notificationSet.getContentText()));
+            }
+
 
             mNotifyMgr.notify(notificationSet.getModId(), mBuilder.build());
         }

--- a/app/src/main/java/set/NotificationSet.java
+++ b/app/src/main/java/set/NotificationSet.java
@@ -15,6 +15,7 @@ public class NotificationSet implements RealmModel {
     private int modId;
     private int courseID;
     private String courseName;
+    private String sectionName;
     private String moduleName;
 
     public NotificationSet() {
@@ -47,6 +48,14 @@ public class NotificationSet implements RealmModel {
         this.courseName = courseName;
     }
 
+    public String getSectionName() {
+        return sectionName;
+    }
+
+    public void setSectionName(String sectionName) {
+        this.sectionName = sectionName;
+    }
+
     public String getModuleName() {
         return moduleName;
     }
@@ -55,9 +64,10 @@ public class NotificationSet implements RealmModel {
         this.moduleName = moduleName;
     }
 
-    public NotificationSet(Course course, Module module) {
+    public NotificationSet(Course course, CourseSection section, Module module) {
         this.courseID = course.getId();
         this.courseName = course.getShortname();
+        this.sectionName = section.getName();
         this.modId = module.getId();
         this.moduleName = module.getName();
     }


### PR DESCRIPTION
Changes made in the PR:
1. The course name for the notification is added as it's summary
2. The section name is it's title and the module name is it's context

For lower API devices it remains the same