### PR TITLE
Null pointer exception in TokenActivity.onCreate()

### DIFF
--- a/app/src/main/java/crux/bphc/cms/TokenActivity.java
+++ b/app/src/main/java/crux/bphc/cms/TokenActivity.java
@@ -55,13 +55,13 @@ public class TokenActivity extends AppCompatActivity {
         setContentView(R.layout.activity_token);
         ButterKnife.bind(this);
 
+        progressDialog = new ProgressDialog(this);
+
         userAccount = new UserAccount(this);
         checkLoggedIn();
 
         Retrofit retrofit = APIClient.getRetrofitInstance();
         moodleServices = retrofit.create(MoodleServices.class);
-
-        progressDialog = new ProgressDialog(this);
 
         courseDataHandler = new CourseDataHandler(this);
         courseRequestHandler = new CourseRequestHandler(this);


### PR DESCRIPTION
If the user has already logged in (i.e provided token) then the app
crashes since a ProgressDialog would'nt have been instantiated yet but
would still be dismissed.