### PR TITLE
Issue #80 Mark all as Read

### DIFF
--- a/app/src/main/res/menu/my_courses_menu.xml
+++ b/app/src/main/res/menu/my_courses_menu.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/mark_all_as_read"
+        android:title="@string/mark_all_as_read"
+        app:showAsAction="ifRoom" />
+</menu>


### PR DESCRIPTION
Added an options menu in the MyCourses fragment which marks all modules of all sections of all courses as read.
Currently, this process takes a noticeable amount of time with large number of modules. I'm assuming it's the
Realm transactions which need to be done for each module. If possible, this should be made asynchronous so that
UI feels more snappy.