### PR TITLE
Hyperlinks are rendered properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 Dates are in `yyyy-mm-dd`.
 
 ## Unreleased
+<<<<<<< HEAD
 ### Added
 * Dark theme for the app, with a toggle in the settings. System preview window will be dark by default.
 
 ### Fixed
 * Repeated notifications of very old forum discussions
+* Hyperlinks not clickable in forums posts and course section descriptions #92
 
 ## Version 1.4.1 (verCode 8), 2018-09-08
 ### Added

--- a/app/src/main/java/crux/bphc/cms/fragments/DiscussionFragment.java
+++ b/app/src/main/java/crux/bphc/cms/fragments/DiscussionFragment.java
@@ -4,6 +4,7 @@ package crux.bphc.cms.fragments;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
+import android.text.method.LinkMovementMethod;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -91,7 +92,8 @@ public class DiscussionFragment extends Fragment implements MyFileManager.Callba
         mTimeModified.setText(ForumFragment.formatDate(discussion.getTimemodified()));
 
         mMessage = view.findViewById(R.id.message);
-        mMessage.setText(discussion.getMessage());
+        mMessage.setText(HtmlTextView.parseHtml(discussion.getMessage()));
+        mMessage.setMovementMethod(LinkMovementMethod.getInstance());
 
         mAttachmentContainer = view.findViewById(R.id.attachments);
         LayoutInflater inflater = LayoutInflater.from(getContext());

--- a/app/src/main/java/crux/bphc/cms/fragments/ForumFragment.java
+++ b/app/src/main/java/crux/bphc/cms/fragments/ForumFragment.java
@@ -289,7 +289,7 @@ public class ForumFragment extends Fragment {
                 mSubject.setText(discussion.getSubject());
                 mUserName.setText(discussion.getUserfullname());
                 mModifiedTime.setText(formatDate(discussion.getTimemodified()));
-                mMessage.setText(discussion.getMessage());
+                mMessage.setText(HtmlTextView.parseHtml((discussion.getMessage())));
             }
         }
     }

--- a/app/src/main/java/helper/HtmlTextView.java
+++ b/app/src/main/java/helper/HtmlTextView.java
@@ -5,7 +5,11 @@ import android.os.Build;
 import android.support.v7.widget.AppCompatTextView;
 import android.text.Html;
 import android.text.Spanned;
+import android.text.TextUtils;
+import android.text.method.LinkMovementMethod;
 import android.util.AttributeSet;
+import android.util.Log;
+import android.util.LogPrinter;
 
 public class HtmlTextView extends AppCompatTextView {
 
@@ -23,12 +27,12 @@ public class HtmlTextView extends AppCompatTextView {
 
     @Override
     public void setText(CharSequence text, BufferType type) {
-        super.setText(parseHtml(text.toString()), type);
+        super.setText(text, type);
     }
 
     public static Spanned parseHtml(String text) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            return Html.fromHtml(text, Html.FROM_HTML_MODE_LEGACY);
+            return Html.fromHtml(text, Html.FROM_HTML_MODE_COMPACT);
         } else {
             //noinspection deprecation
             return Html.fromHtml(text);

--- a/app/src/main/java/helper/Util.java
+++ b/app/src/main/java/helper/Util.java
@@ -1,0 +1,86 @@
+package helper;
+
+/**
+ * Set of utility functions that can be used throughout the entire project.
+ *
+ * Created by abhijeetviswa 21/04/2019
+ */
+public class Util {
+
+    /**
+     * Start from <code>start</code> and finds the next word. A word is a sequence of 4 or more characters that ends with a whitespace or a newline.
+     * @param str The string in which you want to find the next word
+     * @param start The index position starting from which the next word is to be found
+     * @return
+     */
+    public static String nextNearestWord(String str, int start)
+    {
+        boolean foundWord = false;
+        int i = start, t = -1;
+        while (!foundWord)
+        {
+            if (i >= str.length()) break; /* We didn't find any word :( */
+
+            char ch = str.charAt(i);
+            if (ch != '\n' && ch != ' ') {
+                if (t == -1) t = i;
+                i++;
+            }
+            else if (i != start && t != -1)
+            {
+                if ((i - t)  >= 4)
+                    foundWord = true;
+                else {
+                    i++;
+                    t = -1;
+                }
+            }else i++;
+        }
+        if (foundWord) return str.substring(t, i);
+        else return ""; /* We probably started at the end of the string */
+    }
+
+    /**
+     * Counts the number of occurrences of <code>word</code> in <code>str</code>
+     * @param str The string in which you want to search
+     * @param word The word whose occurrence count you want
+     * @return an integer representing the number of occurrences
+     */
+    public static int countOccurrencesOfWord(String str, String word)
+    {
+        int count = 0, startIndex = 0;
+        while ((startIndex = str.indexOf(word, startIndex)) != -1)
+        {
+            count++;
+            startIndex++;
+        }
+
+        return count;
+    }
+
+    /**
+     * Gets the index of the nth occurrence of  <code>word</code> in <code>str</code>
+     * If the word doesn't occur a minimum of n times, -1 is returned
+     * @param str
+     * @param word
+     * @param n
+     * @return an integer representing the index of the nth occurrence, else -1
+     */
+    public static int indexOfOccurrence(String str, String word, int n)
+    {
+        if (n <= 0) throw new IllegalArgumentException("n should be an integer greater than or equal to 1");
+
+        int count = 0, startIndex = 0;
+        while ((startIndex = str.indexOf(word, startIndex)) != -1)
+        {
+            count++;
+            if (count == n) break; /* We have found the nth occurrence */
+            startIndex++;
+        }
+
+        if (count != n) return -1; /* There weren't n occurrences */
+        return startIndex;
+    }
+
+
+}

--- a/app/src/main/res/layout/row_course_section.xml
+++ b/app/src/main/res/layout/row_course_section.xml
@@ -32,8 +32,7 @@
             android:textStyle="bold" />
     </LinearLayout>
 
-    <TextView
-        android:autoLink="all"
+    <helper.HtmlTextView
         android:clickable="true"
         android:focusable="true"
         android:visibility="gone"


### PR DESCRIPTION
Hyperlinks in CoureSections and Discussions weren't being rendered properly

CourseSection descriptions are HTML strings with anchor tags to mark links.
However, insertion of the "Show More" span removes the URLSpan created from
the original HTML string by converting the spanned string to a plain string.
This commit ensures that the "Show More" span is added along with the URLSpan
instead of overwriting the URLSpan.

Discussions didn't have support for hyperlinks

Close #92