### PR TITLE
Fix Notification Spam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Dates are in `yyyy-mm-dd`.
 ### Added
 * Dark theme for the app, with a toggle in the settings. System preview window will be dark by default.
 
+### Fixed
+* Repeated notifications of very old forum discussions
 
 ## Version 1.4.1 (verCode 8), 2018-09-08
 ### Added


### PR DESCRIPTION
Notifications for very old announcements were being created. 

If a user goes to a Forum fragment, this results in the latest 20 discussions in that forum to be fetched and saved in Realm. The next time the Notification job runs, all of the discussions would be fetched and compared against the discussions cached locally. If total number of discussions is greater than 20 then the very old discussions would be treated as new since they would not be in the local cache and notifications would be issued for them.

Close #98