### PR TITLE
Checked item is updated in Navigation view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 Dates are in `yyyy-mm-dd`.
 
 ## Unreleased
+### Fixed
+Checked item in Navigation View in Main Activity is not getting updated when we click in the Navigation Bar, on any other fragment  other than My courses and press the back button.
 
 ## Version 1.4.1 (verCode 8), 2018-09-08
 ### Added

--- a/app/src/main/java/crux/bphc/cms/MainActivity.java
+++ b/app/src/main/java/crux/bphc/cms/MainActivity.java
@@ -46,6 +46,7 @@ public class MainActivity extends AppCompatActivity
     private static final int MY_PERMISSIONS_REQUEST_WRITE_STORAGE = 1001;
     private UserAccount mUserAccount;
     private Fragment fragment;
+    NavigationView navigationView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -72,7 +73,7 @@ public class MainActivity extends AppCompatActivity
         };
         drawer.setDrawerListener(toggle);
         toggle.syncState();
-        NavigationView navigationView = findViewById(R.id.nav_view);
+        navigationView = findViewById(R.id.nav_view);
         navigationView.setNavigationItemSelectedListener(this);
 
         View headerView = navigationView.getHeaderView(0);
@@ -236,6 +237,7 @@ public class MainActivity extends AppCompatActivity
         } else if (getSupportFragmentManager().getBackStackEntryCount() != 0) {
             super.onBackPressed();
         } else if (!(fragment instanceof MyCoursesFragment)) {
+            navigationView.setCheckedItem(R.id.my_courses);
             setHome();
         } else {
             super.onBackPressed();


### PR DESCRIPTION
The checked item in Navigation view in Main Activity was not getting updated when user clicks on any other menu item to open any other fragment other than My Courses and then press the back button to come back on My Courses fragment.
Fixed that by updating the onBackPressed method in MainActivity.java file.

Close #102