### PR TITLE
Update Changelog to include dark theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 Dates are in `yyyy-mm-dd`.
 
 ## Unreleased
+### Added
+* Dark theme for the app, with a toggle in the settings. System preview window will be dark by default.
+
 
 ## Version 1.4.1 (verCode 8), 2018-09-08
 ### Added


### PR DESCRIPTION
This was missed and should have been included in the `dark_theme` branch PR.