### PR TITLE
Back button from SettingsActivity applies theme

### DIFF
--- a/app/src/main/java/crux/bphc/cms/SettingsActivity.java
+++ b/app/src/main/java/crux/bphc/cms/SettingsActivity.java
@@ -2,9 +2,12 @@ package crux.bphc.cms;
 
 
 import android.os.Bundle;
+import android.provider.Settings;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.SwitchCompat;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.widget.CompoundButton;
 
 import app.MyApplication;
@@ -18,12 +21,16 @@ public class SettingsActivity extends AppCompatActivity {
     @BindView(R.id.darkModeSwitch)
     SwitchCompat darkModeSwitch;
 
+    boolean themeChanged;
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         if (MyApplication.getInstance().isDarkModeEnabled()) {
             setTheme(R.style.AppTheme_Dark);
         }
 
+        if (savedInstanceState != null && savedInstanceState.containsKey("themeChanged")) {
+            themeChanged = savedInstanceState.getBoolean("themeChanged");
+        }
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_settings);
         ButterKnife.bind(this);
@@ -36,9 +43,27 @@ public class SettingsActivity extends AppCompatActivity {
         });
 
         darkModeSwitch.setChecked(MyApplication.getInstance().isDarkModeEnabled());
+
         darkModeSwitch.setOnCheckedChangeListener((compoundButton, isChecked) -> {
             MyApplication.getInstance().setDarkModeEnabled(isChecked);
+            this.themeChanged = !themeChanged; // If we go light -> dark -> light, we don't need to retheme
             recreate();
         });
     }
+
+    @Override
+    public void onBackPressed() {
+        if (themeChanged) {
+            onNavigateUp();
+        }else{
+            super.onBackPressed();
+        }
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState){
+        outState.putBoolean("themeChanged", themeChanged);
+        super.onSaveInstanceState(outState);
+    }
+
 }

--- a/app/src/main/java/crux/bphc/cms/service/NotificationService.java
+++ b/app/src/main/java/crux/bphc/cms/service/NotificationService.java
@@ -49,22 +49,6 @@ public class NotificationService extends JobService {
      * NOT called by the service itself.
      */
     public static void startService(Context context, boolean replace) {
-        /*
-         * Build JobInfo object. Job will run once per hour, on any type of network,
-         * and persist across reboots.
-         *
-         * By using JobScheduler, the method `onStartJob` will be executed taking into consideration
-         * Doze mode etc.
-         *
-         * This particular periodic job will execute exactly once within a 1 hour period,
-         * but may do so at any time, not necessarily at the end of it. The exact time of execution
-         * is subject to the optimizations of the Android OS based on other scheduled jobs, idle time etc.
-         */
-        ComponentName serviceComponent = new ComponentName(context, NotificationService.class);
-        JobInfo.Builder builder = new JobInfo.Builder(CMS_JOB_ID, serviceComponent)
-                .setPeriodic(TimeUnit.HOURS.toMillis(1))
-                .setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
-                .setPersisted(true);
 
         // Get an instance of the system JobScheduler service.
         JobScheduler jobScheduler = (JobScheduler) context.getSystemService(Context.JOB_SCHEDULER_SERVICE);
@@ -82,6 +66,23 @@ public class NotificationService extends JobService {
                 }
             }
         }
+
+        /*
+         * Build JobInfo object. Job will run once per hour, on any type of network,
+         * and persist across reboots.
+         *
+         * By using JobScheduler, the method `onStartJob` will be executed taking into consideration
+         * Doze mode etc.
+         *
+         * This particular periodic job will execute exactly once within a 1 hour period,
+         * but may do so at any time, not necessarily at the end of it. The exact time of execution
+         * is subject to the optimizations of the Android OS based on other scheduled jobs, idle time etc.
+         */
+        ComponentName serviceComponent = new ComponentName(context, NotificationService.class);
+        JobInfo.Builder builder = new JobInfo.Builder(CMS_JOB_ID, serviceComponent)
+                .setPeriodic(TimeUnit.HOURS.toMillis(1))
+                .setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
+                .setPersisted(true);
 
         // Pass our job to the JobScheduler in order to queue it.
         jobScheduler.schedule(builder.build());


### PR DESCRIPTION
After the theme has been changed from the settings menu and the software
back button is pressed, the theme wouldn't update properly.

The theme is applied while an activity is created. However, the software back
button doesn't recreate the previous activity, it just resumes it. This commit
makes sure that the activity is re-created only if required. If there is no
theme change, the previous activity will be resumed.

Sequence of creation of the NotificationService has been modified to allow for
early exit if need be.

Close: #111