### PR TITLE
Issue #137: Added the ability to share modules without having to download them

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,7 +41,18 @@
             android:name=".MainActivity"
             android:label="@string/app_name"
             android:screenOrientation="portrait"
-            android:theme="@style/AppTheme.NoActionBar" />
+            android:theme="@style/AppTheme.NoActionBar"
+            >
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:scheme="https" android:host="td.bits-hyderabad.ac.in"
+                    android:pathPrefix="/fileShare" />
+            </intent-filter>
+
+        </activity>
 
         <activity
             android:name=".CourseDetailActivity"

--- a/app/src/main/java/crux/bphc/cms/CourseModulesActivity.java
+++ b/app/src/main/java/crux/bphc/cms/CourseModulesActivity.java
@@ -32,6 +32,7 @@ public class CourseModulesActivity extends AppCompatActivity {
     MyFileManager mFileManager;
     boolean newFileDownloaded = false;
     String courseName = "";
+    int courseID;
 
     private void setDownloaded(String fileName) {
         myAdapter.notifyDataSetChanged();
@@ -59,7 +60,8 @@ public class CourseModulesActivity extends AppCompatActivity {
         RealmResults<CourseSection> sections = realm.where(CourseSection.class).equalTo("id", sectionID).findAll();
 
         setTitle(sections.first().getName());
-        courseName = CourseDataHandler.getCourseName(sections.first().getCourseID());
+        courseID = sections.first().getCourseID();
+        courseName = CourseDataHandler.getCourseName(courseID);
         mFileManager = new MyFileManager(this, courseName);
         modules = sections.first().getModules();
         if (modules.size() == 0) {
@@ -68,7 +70,7 @@ public class CourseModulesActivity extends AppCompatActivity {
 
         RecyclerView recyclerView = findViewById(R.id.recyclerView);
 
-        myAdapter = new ModulesAdapter(this, mFileManager, courseName);
+        myAdapter = new ModulesAdapter(this, mFileManager, courseName, courseID);
         myAdapter.setModules(modules);
         recyclerView.setAdapter(myAdapter);
         recyclerView.setLayoutManager(new LinearLayoutManager(this));

--- a/app/src/main/java/crux/bphc/cms/fragments/CourseSectionFragment.java
+++ b/app/src/main/java/crux/bphc/cms/fragments/CourseSectionFragment.java
@@ -278,7 +278,7 @@ public class CourseSectionFragment extends Fragment {
 
         RecyclerView recyclerView = v.findViewById(R.id.recyclerView);
 
-        final ModulesAdapter myAdapter = new ModulesAdapter(getContext(), mFileManager, courseName);
+        final ModulesAdapter myAdapter = new ModulesAdapter(getContext(), mFileManager, courseName, courseId);
         myAdapter.setModules(section.getModules());
         recyclerView.setAdapter(myAdapter);
         recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));

--- a/app/src/main/java/helper/ModulesAdapter.java
+++ b/app/src/main/java/helper/ModulesAdapter.java
@@ -2,6 +2,7 @@ package helper;
 
 import android.content.Context;
 import android.content.DialogInterface;
+import android.content.Intent;
 import android.graphics.Color;
 import androidx.core.content.ContextCompat;
 import androidx.appcompat.app.AlertDialog;
@@ -43,14 +44,16 @@ public class ModulesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
     private List<Module> modules;
     private ClickListener clickListener;
     private String courseName;
+    private int courseID;
     private int maxDescriptionlines = 3;
 
-    public ModulesAdapter(Context context, MyFileManager fileManager, String courseName) {
+    public ModulesAdapter(Context context, MyFileManager fileManager, String courseName, int courseID) {
         this.context = context;
         inflater = LayoutInflater.from(context);
         modules = new ArrayList<>();
         mFileManager = fileManager;
         this.courseName = courseName;
+        this.courseID = courseID;
         courseDataHandler = new CourseDataHandler(context);
     }
 
@@ -142,6 +145,7 @@ public class ModulesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                     arrayAdapter.add("Mark as Unread");
                 } else {
                     arrayAdapter.add("Download");
+                    arrayAdapter.add("Share");
                     arrayAdapter.add("Mark as Unread");
                 }
 
@@ -185,6 +189,9 @@ public class ModulesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                                     mFileManager.downloadFile(module.getContents().get(0), module, courseName);
                                     break;
                                 case 1:
+                                    shareModuleLinks(module);
+                                    break;
+                                case 2:
                                     markAsReadandUnread(module, position, true);
                             }
 
@@ -201,6 +208,19 @@ public class ModulesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
             courseDataHandler.markAsReadandUnread(module.getId(), isNewContent);
             modules.get(position).setNewContent(isNewContent);
             notifyItemChanged(position);
+        }
+
+        private void shareModuleLinks(Module module) {
+            String toShare = "";
+            if (module.getContents() != null)
+                for (Content content : module.getContents()) {
+                    toShare += content.getFileurl().replace("/moodle", "/fileShare/moodle") + "&courseName=" + courseName.replace(" ", "%20") + "&courseId=" + courseID;
+                }
+
+            Intent sharingIntent = new Intent(android.content.Intent.ACTION_SEND);
+            sharingIntent.setType("text/plain");
+            sharingIntent.putExtra(Intent.EXTRA_TEXT, toShare);
+            itemView.getContext().startActivity(Intent.createChooser(sharingIntent, null));
         }
 
         void bind(Module module) {


### PR DESCRIPTION
One can now share a link using any text message app and that link can be opened by the receiving user using the app which will open the file in the browser using the receiving user's
token. If they are not enrolled in the course of which the shared module is a part,
they are shown a Toast which says that they need to enroll in this course in order to
view that file.

close #137