### PR TITLE
Site news notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Dates are in `yyyy-mm-dd`.
 * Google Login
 * Ability to share modules without having to download them
 * Fragment for Folder Modules
+* Notifications for Site News
 
 ### Changed
 * Module names are clickable

--- a/app/src/main/java/crux/bphc/cms/service/NotificationService.java
+++ b/app/src/main/java/crux/bphc/cms/service/NotificationService.java
@@ -1,5 +1,6 @@
 package crux.bphc.cms.service;
 
+import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.job.JobInfo;
@@ -187,9 +188,9 @@ public class NotificationService extends JobService {
                                 d.setForumId(module.getInstance());
                             }
                             List<Discussion> newDiscussions = courseDataHandler.setForumDiscussions(module.getInstance(), discussions);
-                            if(newDiscussions.size() > 0)  courseDataHandler.markAsReadandUnread(module.getId(), true);
+                            if (newDiscussions.size() > 0)  courseDataHandler.markAsReadandUnread(module.getId(), true);
                             for (Discussion discussion : newDiscussions) {
-                                createNotifModuleAdded(new NotificationSet(course, module, discussion));
+                                createNotifModuleAdded(NotificationSet.createNotificationSet(course, module, discussion));
                             }
                         }
                     }
@@ -199,13 +200,25 @@ public class NotificationService extends JobService {
             }
         }
 
+        // Create notifications for site news
+        List<Discussion> discussions = courseRequestHandler.getForumDiscussions(1); // 1 is always site news
+        if (discussions != null) {
+            for (Discussion d : discussions) {
+                d.setForumId(1);
+            }
+            List<Discussion> newDiscussions = courseDataHandler.setForumDiscussions(1, discussions);
+            for (Discussion discussion : newDiscussions) {
+                createNotifModuleAdded(new NotificationSet(discussion.getId(), 1, "Site News", discussion.getMessage(), null));
+            }
+        }
+        
         mJobRunning = false;
         jobFinished(job, false);
     }
 
     private void createNotifSectionAdded(CourseSection section, Course course) {
         for (Module module : section.getModules()) {
-            createNotifModuleAdded(new NotificationSet(course, section, module));
+            createNotifModuleAdded(NotificationSet.createNotificationSet(course, section, module));
         }
     }
 

--- a/app/src/main/java/set/NotificationSet.java
+++ b/app/src/main/java/set/NotificationSet.java
@@ -14,7 +14,7 @@ public class NotificationSet implements RealmModel {
 
     @PrimaryKey
     private int uniqueId;
-    private int bundleID;
+    private int bundleId;
     private String notifSummary;
     private String notifTitle;
     private String notifContext;
@@ -22,11 +22,25 @@ public class NotificationSet implements RealmModel {
     public NotificationSet() {
     }
 
-    public NotificationSet(int courseID, String courseName, int modId, String moduleName) {
-        this.bundleID = courseID;
-        this.notifSummary = courseName;
-        this.uniqueId = modId;
-        this.notifContext = moduleName;
+    public NotificationSet(int uniqueId, int bundleId, String notifTitle, String notifContext, String notifSummary) {
+        this.uniqueId = uniqueId;
+        this.bundleId = bundleId;
+        this.notifTitle = notifTitle;
+        this.notifContext = notifContext;
+        this.notifSummary = notifSummary;
+    }
+
+    /** Helper methods to create NotificationSet objects */
+    public static NotificationSet createNotificationSet(Course course, CourseSection section, Module module) {
+        return new NotificationSet(module.getId(), course.getId(), section.getName(), module.getName(), course.getShortname());
+    }
+
+    public static NotificationSet createNotificationSet(Course course, Module module, Discussion discussion) {
+        return new NotificationSet(discussion.getId(), course.getId(), module.getName(), discussion.getName(), course.getShortname());
+    }
+
+    public static NotificationSet createNotificationSet(int courseID, String courseName, int modId, String moduleName) {
+        return new NotificationSet(modId, courseID, "", moduleName, courseName);
     }
 
     public int getUniqueId() {
@@ -34,12 +48,12 @@ public class NotificationSet implements RealmModel {
     }
 
     public int getBundleID() {
-        return bundleID;
+        return bundleId;
     }
 
 
     public void setBundleID(int bundleID) {
-        this.bundleID = bundleID;
+        this.bundleId = bundleID;
     }
 
     public String getNotifSummary() {
@@ -65,23 +79,6 @@ public class NotificationSet implements RealmModel {
     public void setNotifContext(String notifContext) {
         this.notifContext = notifContext;
     }
-
-    public NotificationSet(Course course, CourseSection section, Module module) {
-        this.bundleID = course.getId();
-        this.notifSummary = course.getShortname();
-        this.notifTitle = section.getName();
-        this.uniqueId = module.getId();
-        this.notifContext = module.getName();
-    }
-
-    public NotificationSet(Course course, Module module, Discussion discussion) {
-        this.bundleID = course.getId();
-        this.notifSummary = course.getShortname();
-        this.notifTitle = module.getName();
-        this.notifContext = discussion.getName();
-        this.uniqueId = discussion.getId();
-    }
-
 
     public void setUniqueId(int uniqueId) {
         this.uniqueId = uniqueId;


### PR DESCRIPTION
New discussions in site news weren't notified. This meant that important
site news would go missed by students.

All site news, under the title "Site News" are notified at the same
frequency as the notifications for other course sections, modules and
discussions

Close #113