### PR TITLE
Create FolderModuleFragment to support Folder modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Dates are in `yyyy-mm-dd`.
 ### Added
 * Google Login
 * Ability to share modules without having to download them
+* Fragment for Folder Modules
+
 ### Changed
 * Module names are clickable
 

--- a/app/src/main/java/crux/bphc/cms/fragments/FolderModuleFragment.java
+++ b/app/src/main/java/crux/bphc/cms/fragments/FolderModuleFragment.java
@@ -1,0 +1,265 @@
+package crux.bphc.cms.fragments;
+
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.ImageView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import app.MyApplication;
+import crux.bphc.cms.R;
+import helper.ClickListener;
+import helper.MyFileManager;
+import io.realm.Realm;
+import set.Content;
+import set.Module;
+
+import static app.Constants.API_URL;
+
+public class FolderModuleFragment extends Fragment {
+
+    private static final String TOKEN_KEY = "token";
+    private static final String MODULE_ID_KEY = "moduleID";
+    private static final String COURSE_NAME_KEY = "courseName";
+
+    private String TOKEN = "";
+    private int MODULE_INSTANCE = 0;
+    private String COURSE_NAME = "";
+    private String MOD_NAME = "";
+
+    private Module module;
+    private List<Content> contents;
+
+    private FolderModuleFragment.FolderModuleAdapter mAdapter;
+    private ClickListener mClickListener;
+    private Realm realm;
+    private MyFileManager mFileManager;
+
+    private RecyclerView mRecyclerView;
+
+    public FolderModuleFragment() {
+
+    }
+
+    public static FolderModuleFragment newInstance(String token, int moduleId, String courseName) {
+        FolderModuleFragment fragment = new FolderModuleFragment();
+        Bundle args = new Bundle();
+        args.putString(TOKEN_KEY, token);
+        args.putInt(MODULE_ID_KEY, moduleId);
+        args.putString(COURSE_NAME_KEY, courseName);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (getArguments() != null) {
+            TOKEN = getArguments().getString(TOKEN_KEY);
+            MODULE_INSTANCE = getArguments().getInt(MODULE_ID_KEY);
+            COURSE_NAME = getArguments().getString(COURSE_NAME_KEY);
+        }
+
+        realm = MyApplication.getInstance().getRealmInstance();
+
+        // If we NPE, lite
+        module = realm.where(Module.class).equalTo("instance", MODULE_INSTANCE).findFirst();
+        contents = module.getContents();
+
+        mFileManager = new MyFileManager(getActivity(), COURSE_NAME);
+        mFileManager.registerDownloadReceiver();
+        mFileManager.setCallback(new MyFileManager.Callback() {
+            @Override
+            public void onDownloadCompleted(String fileName) {
+                mAdapter.notifyDataSetChanged();
+                mFileManager.openFile(fileName, COURSE_NAME);
+            }
+        });
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        // Inflate the layout for this fragment
+        return inflater.inflate(R.layout.fragment_folder_module, container, false);
+    }
+
+    @Override
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        mClickListener = new ClickListener() {
+            @Override
+            public boolean onClick(Object object, int position) {
+                Content content = (Content) object;
+                downloadOrOpenFile(content, false);
+                return true;  // why is this here?
+            }
+        };
+
+        mRecyclerView = view.findViewById(R.id.files);
+        final LinearLayoutManager layoutManager = new LinearLayoutManager(getContext());
+        mRecyclerView.setLayoutManager(layoutManager);
+
+        mAdapter = new FolderModuleFragment.FolderModuleAdapter(mClickListener, new ArrayList<Content>());
+        mRecyclerView.setAdapter(mAdapter);
+
+        updateContents();
+    }
+
+    private void updateContents() {
+        mAdapter.setContents(contents);
+    }
+
+    private void downloadOrOpenFile(Content content, boolean forceDownload) {
+        if (forceDownload || !mFileManager.searchFile(content.getFilename())) {
+            Toast.makeText(getActivity(), "Downloading file - " + content.getFilename(), Toast.LENGTH_SHORT).show();
+            mFileManager.downloadFile(content, module, COURSE_NAME);
+        } else {
+            mFileManager.openFile(content.getFilename(), COURSE_NAME);
+        }
+    }
+
+
+    private class FolderModuleAdapter extends RecyclerView.Adapter<FolderModuleFragment.FolderModuleAdapter.FolderModuleViewHolder> {
+
+        private List<Content> mContents;
+        private ClickListener mClickListener;
+
+        public FolderModuleAdapter(ClickListener clickListener, List<Content> contents) {
+            mClickListener = clickListener;
+            mContents = contents;
+        }
+
+        public void setContents(List<Content> contents) {
+            mContents.addAll(contents);
+            notifyDataSetChanged();
+        }
+
+        public List<Content> getContents() {
+            return mContents;
+        }
+
+        public void clearContents() {
+            mContents.clear();
+            notifyDataSetChanged();
+        }
+
+        @Override
+        public FolderModuleFragment.FolderModuleAdapter.FolderModuleViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+            LayoutInflater inflater = LayoutInflater.from(parent.getContext());
+            return new FolderModuleFragment.FolderModuleAdapter.FolderModuleViewHolder(inflater.inflate(R.layout.row_folder_module_file, parent, false));
+        }
+
+        @Override
+        public void onBindViewHolder(FolderModuleFragment.FolderModuleAdapter.FolderModuleViewHolder holder, int position) {
+            Content content = mContents.get(position);
+            holder.bind(content);
+        }
+
+        @Override
+        public int getItemCount() {
+            return mContents.size();
+        }
+
+
+        public class FolderModuleViewHolder extends RecyclerView.ViewHolder {
+
+            private TextView fileName;
+            private ImageView fileIcon;
+            private ImageView download;
+            private ImageView ellipsis;
+            
+            public FolderModuleViewHolder(View itemView) {
+                super(itemView);
+                itemView.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        int position = getLayoutPosition();
+                        mClickListener.onClick(mContents.get(position), position);
+                    }
+                });
+
+                fileName = itemView.findViewById(R.id.fileName);
+                fileIcon = itemView.findViewById(R.id.fileIcon);
+                download = itemView.findViewById(R.id.downloadButton);
+                ellipsis = itemView.findViewById(R.id.more);
+            }
+
+            public void bind(Content content) {
+                fileName.setText(content.getFilename());
+
+                int icon = MyFileManager.getIconFromFileName(content.getFilename());
+                if (icon != -1) {
+                    fileIcon.setImageResource(icon);
+                } else {
+                    fileIcon.setImageResource(R.drawable.quiz); // Quiz because that's a question mark xD
+                }
+
+                boolean downloaded = mFileManager.searchFile(content.getFilename());
+                if (downloaded) {
+                    download.setImageResource(R.drawable.eye);
+                }
+
+                download.setOnClickListener(view -> {
+                    if (mClickListener != null) {
+                        mClickListener.onClick(contents.get(getLayoutPosition()), getLayoutPosition());
+                    }
+                });
+
+                ellipsis.setOnClickListener(view -> {
+                    AlertDialog.Builder alertDialog;
+
+                    if (MyApplication.getInstance().isDarkModeEnabled()) {
+                        alertDialog = new AlertDialog.Builder(getContext(), R.style.Theme_AppCompat_Dialog_Alert);
+                    } else {
+                        alertDialog = new AlertDialog.Builder(getContext(), R.style.Theme_AppCompat_Light_Dialog_Alert);
+                    }
+
+                    alertDialog.setTitle(content.getFilename());
+
+                    final ArrayAdapter<String> arrayAdapter = new ArrayAdapter<String>(getContext(), android.R.layout.simple_list_item_1);
+                    if (downloaded) {
+                        arrayAdapter.add("View");
+                        arrayAdapter.add("Re-Download");
+                        arrayAdapter.add("Share");
+                    } else {
+                        arrayAdapter.add("Download");
+                    }
+
+                    alertDialog.setNegativeButton("Cancel", null);
+                    alertDialog.setAdapter(arrayAdapter, new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialogInterface, int i) {
+                                switch (i) {
+                                    case 0: // View/Download
+                                        downloadOrOpenFile(content, false);
+                                        break;
+                                    case 1:
+                                        downloadOrOpenFile(content, true);
+                                        break;
+                                    case 2:
+                                        mFileManager.shareFile(content.getFilename(), COURSE_NAME);
+                                        break;
+                                }
+                            }
+                        }
+                    );
+                    alertDialog.show();
+                });
+            }
+        }
+    }
+}

--- a/app/src/main/java/helper/ModulesAdapter.java
+++ b/app/src/main/java/helper/ModulesAdapter.java
@@ -242,7 +242,7 @@ public class ModulesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                 description.setVisibility(View.GONE);
             }
             iconWrapper.setVisibility(View.VISIBLE);
-            if (!module.isDownloadable()) {
+            if (!module.isDownloadable() || module.getModType() == Module.Type.FOLDER) {
                 downloadIcon.setImageResource(R.drawable.eye);
             } else {
                 List<Content> contents = module.getContents();
@@ -263,9 +263,9 @@ public class ModulesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
             if (module.getModType() == Module.Type.LABEL) {
                 iconWrapper.setVisibility(View.GONE);
             } else {
-                int resourceIcon = module.getResourceIcon();
+                int resourceIcon = module.getModuleIcon();
                 if (resourceIcon != -1) {
-                    modIcon.setImageResource(module.getResourceIcon());
+                    modIcon.setImageResource(module.getModuleIcon());
                 } else {
                     progressBar.setVisibility(View.VISIBLE);
                     Picasso.with(context).load(module.getModicon()).into(modIcon, new Callback() {

--- a/app/src/main/java/helper/MyFileManager.java
+++ b/app/src/main/java/helper/MyFileManager.java
@@ -29,6 +29,7 @@ import app.Constants;
 import app.MyApplication;
 import crux.bphc.cms.BuildConfig;
 import crux.bphc.cms.R;
+import crux.bphc.cms.fragments.FolderModuleFragment;
 import crux.bphc.cms.fragments.ForumFragment;
 import set.Content;
 import set.Module;
@@ -46,8 +47,7 @@ public class MyFileManager {
     private Callback callback;
     private String courseDirName;
     private BroadcastReceiver onComplete = new BroadcastReceiver() {
-        public void onReceive(Context ctxt, Intent intent) {
-            int i = 0;
+        public void onReceive(Context context, Intent intent) {
             reloadFileList();
             for (String filename : requestedDownloads) {
                 if (searchFile(filename)) {
@@ -57,7 +57,6 @@ public class MyFileManager {
                     }
                     return;
                 }
-                i++;
             }
         }
     };
@@ -80,7 +79,29 @@ public class MyFileManager {
         activity.startActivity(intent);
     }
 
-    private String getApplicationType(String filename) {
+    public static int getIconFromFileName(String filename) {
+        switch (MyFileManager.getExtension(filename)) {
+            case "pdf":
+                return (R.drawable.file_pdf);
+
+            case "xls":
+            case "xlsx":
+                return (R.drawable.file_excel);
+
+            case "doc":
+            case "docx":
+                return (R.drawable.file_word);
+
+            case "ppt":
+            case "pptx":
+                return (R.drawable.file_powerpoint);
+
+            default:
+                return -1;
+        }
+    }
+
+    private static String getApplicationType(String filename) {
         String extension = getExtension(filename);
         switch (extension) {
             case "pdf":
@@ -232,6 +253,12 @@ public class MyFileManager {
                     .addToBackStack(null)
                     .replace(R.id.course_section_enrol_container, forumFragment, "Announcements");
             fragmentTransaction.commit();
+        } else if (module.getModType() == Module.Type.FOLDER) {
+            Fragment folderModulerFragment = FolderModuleFragment.newInstance(Constants.TOKEN, module.getInstance(), courseName);
+            FragmentTransaction fragmentTransaction = ((AppCompatActivity) activity).getSupportFragmentManager().beginTransaction()
+                    .addToBackStack(null)
+                    .replace(R.id.course_section_enrol_container, folderModulerFragment, "Folder Module");
+            fragmentTransaction.commit();
         } else if (module.getContents() == null || module.getContents().size() == 0) {
             if (module.getModType() == Module.Type.LABEL) {
                 if (module.getDescription() == null || module.getDescription().length() == 0) {
@@ -240,9 +267,9 @@ public class MyFileManager {
                 AlertDialog.Builder alertDialog;
 
                 if (MyApplication.getInstance().isDarkModeEnabled()) {
-                    alertDialog = new AlertDialog.Builder(activity,R.style.Theme_AppCompat_Dialog_Alert);
+                    alertDialog = new AlertDialog.Builder(activity, R.style.Theme_AppCompat_Dialog_Alert);
                 } else {
-                    alertDialog = new AlertDialog.Builder(activity,R.style.Theme_AppCompat_Light_Dialog_Alert);
+                    alertDialog = new AlertDialog.Builder(activity, R.style.Theme_AppCompat_Light_Dialog_Alert);
                 }
 
                 Spanned htmlDescription = Html.fromHtml(module.getDescription());
@@ -253,7 +280,6 @@ public class MyFileManager {
             } else
 
                 showInWebsite(activity, module.getUrl());
-
         } else {
             for (Content content : module.getContents()) {
                 if (!searchFile(content.getFilename())) {

--- a/app/src/main/java/set/Module.java
+++ b/app/src/main/java/set/Module.java
@@ -195,33 +195,12 @@ public class Module extends RealmObject {
      *
      * @return resource id if icon available, else returns -1
      */
-    public int getResourceIcon() {
+    public int getModuleIcon() {
 
         switch (getModType()) {
             //  , QUIZ, URL, PAGE, DEFAULT
             case RESOURCE:
-                switch (MyFileManager.getExtension(getContents().get(0).getFilename())) {
-                    case "pdf":
-                        return (R.drawable.file_pdf);
-
-                    case "xls":
-                    case "xlsx":
-                        return (R.drawable.file_excel);
-
-                    case "doc":
-                    case "docx":
-                        return (R.drawable.file_word);
-
-                    case "ppt":
-                    case "pptx":
-                        return (R.drawable.file_powerpoint);
-
-                    default:
-                        return -1;
-                }
-
-            case DEFAULT:
-                return -1;
+                return MyFileManager.getIconFromFileName(getContents().get(0).getFilename());
 
             case ASSIGNMENT:
                 return (R.drawable.book);
@@ -241,9 +220,12 @@ public class Module extends RealmObject {
             case FORUM:
                 return (R.drawable.forum);
 
+            case DEFAULT:
+                return -1;
         }
         return -1;
     }
+
 
     public boolean isDownloadable() {
         return getContents() != null && getContents().size() != 0 && getModType() != Type.URL && getModType() != Type.FORUM && getModType() != Type.PAGE;

--- a/app/src/main/res/layout/fragment_folder_module.xml
+++ b/app/src/main/res/layout/fragment_folder_module.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:background="?themeBackground"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:clipToPadding="false">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/files"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+    </androidx.recyclerview.widget.RecyclerView>
+
+</FrameLayout>

--- a/app/src/main/res/layout/row_folder_module_file.xml
+++ b/app/src/main/res/layout/row_folder_module_file.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center_horizontal"
+    android:layout_marginTop="8dp"
+    android:background="?cardBgColor"
+    android:padding="8dp">
+
+    <ImageView
+        android:id="@+id/fileIcon"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:padding="8dp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="horizontal" >
+
+        <TextView
+            android:id="@+id/fileName"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:layout_marginTop="15dp"
+            android:layout_marginEnd="15dp"
+            android:layout_marginBottom="15dp"
+            android:layout_gravity="center"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:singleLine="true"
+            android:text="THE QUICK BROWN FOX JUMPED OVER THE LAZY DOG"
+            android:textColor="?android:textColorPrimary"
+            android:textSize="16sp" />
+
+        <ImageView
+            android:id="@+id/downloadButton"
+            android:layout_width="26dp"
+            android:layout_height="26dp"
+            android:background="?android:selectableItemBackgroundBorderless"
+            android:clickable="true"
+            android:focusable="true"
+            android:layout_marginRight="5dp"
+            android:tint="?iconTintColor"
+            android:layout_gravity="center"
+            app:srcCompat="@drawable/download" />
+
+        <ImageView
+            android:id="@+id/more"
+            android:layout_width="26dp"
+            android:layout_height="26dp"
+            android:layout_marginLeft="10dp"
+            android:layout_marginRight="5dp"
+            android:background="?android:selectableItemBackgroundBorderless"
+            android:clickable="true"
+            android:focusable="true"
+            android:tint="?iconTintColor"
+            android:layout_gravity="center|right"
+            app:srcCompat="@drawable/dots_horizontal" />
+    </LinearLayout>
+
+</LinearLayout>


### PR DESCRIPTION
Folder modules are a frequent occurence on CMS, which the app did not
have support for.

Folder modules are essentially a folder of files. Earlier, the app would
download all files inside a folder and would open up the first file of
that folder.

The fragment allows for the listing of all files inside the folder
module.

Close #23