### PR TITLE
Formatting of Site News Notification

### DIFF
--- a/app/src/main/java/crux/bphc/cms/service/NotificationService.java
+++ b/app/src/main/java/crux/bphc/cms/service/NotificationService.java
@@ -208,7 +208,7 @@ public class NotificationService extends JobService {
             }
             List<Discussion> newDiscussions = courseDataHandler.setForumDiscussions(1, discussions);
             for (Discussion discussion : newDiscussions) {
-                createNotifModuleAdded(new NotificationSet(discussion.getId(), 1, "Site News", discussion.getMessage(), null));
+                createNotifModuleAdded(new NotificationSet(discussion.getId(), 1, "Site News", discussion.getMessage().replaceAll("\\<.*?\\>", ""), null));
             }
         }
         


### PR DESCRIPTION
Strips off HTML tags from the discussion message so that they do
not show up in the notiication.

Fixes #147