### PR TITLE
Fix unparsed HTML in notification summary

### DIFF
--- a/app/src/main/java/crux/bphc/cms/service/NotificationService.java
+++ b/app/src/main/java/crux/bphc/cms/service/NotificationService.java
@@ -1,6 +1,5 @@
 package crux.bphc.cms.service;
 
-import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.job.JobInfo;
@@ -13,8 +12,9 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build;
-import androidx.core.app.NotificationCompat;
 import android.util.Log;
+
+import androidx.core.app.NotificationCompat;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -171,7 +171,6 @@ public class NotificationService extends JobService {
                 continue;
             }
 
-
             // update the sections of the course, and get new parts
             // Since new course notifications are skipped, default modules like "Announcements" will not get a notif
             List<CourseSection> newPartsInSection = courseDataHandler.setCourseData(course.getCourseId(), courseSections);
@@ -183,6 +182,7 @@ public class NotificationService extends JobService {
                     for (Module module : modules) {
                         if (module.getModType() == Module.Type.FORUM) {
                             List<Discussion> discussions = courseRequestHandler.getForumDiscussions(module.getInstance());
+
                             if (discussions == null) continue;
                             for (Discussion d : discussions) {
                                 d.setForumId(module.getInstance());
@@ -211,7 +211,7 @@ public class NotificationService extends JobService {
                 createNotifModuleAdded(new NotificationSet(discussion.getId(), 1, "Site News", discussion.getMessage(), null));
             }
         }
-        
+
         mJobRunning = false;
         jobFinished(job, false);
     }
@@ -233,10 +233,10 @@ public class NotificationService extends JobService {
 
             NotificationCompat.Builder groupBuilder = new NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_UPDATES_BUNDLE)
                     .setSmallIcon(R.mipmap.ic_launcher)
-                    .setContentText(notificationSet.getNotifSummary())
+                    .setContentText(parseHtml(notificationSet.getNotifSummary()))
                     .setStyle(new NotificationCompat.InboxStyle()
-                            .setBigContentTitle(notificationSet.getNotifSummary())
-                            .setSummaryText(notificationSet.getNotifSummary()))
+                            .setBigContentTitle(parseHtml(notificationSet.getNotifSummary()))
+                            .setSummaryText(parseHtml(notificationSet.getNotifSummary())))
                     .setGroup(notificationSet.getGroupKey())
                     .setGroupSummary(true)
                     .setAutoCancel(true)
@@ -257,18 +257,16 @@ public class NotificationService extends JobService {
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                 mBuilder.setContentTitle(parseHtml(notificationSet.getNotifTitle()))
-                        .setContentText(parseHtml(notificationSet.getContentText()))
+                        .setContentText(parseHtml(notificationSet.getNotifContent()))
                         .setStyle(new NotificationCompat.InboxStyle()
-                                .setSummaryText(notificationSet.getNotifSummary())
-                                .addLine(notificationSet.getContentText()));
+                                .setSummaryText(parseHtml(notificationSet.getNotifSummary()))
+                                .addLine(parseHtml(notificationSet.getNotifContent())));
                 // Notify the summary notification for post nougat devices only
                 mNotifyMgr.notify(notificationSet.getBundleID(), groupBuilder.build());
             } else {
                 mBuilder.setContentTitle(parseHtml(notificationSet.getNotifSummary()))
-                        .setContentText(parseHtml(notificationSet.getContentText()));
+                        .setContentText(parseHtml(notificationSet.getNotifContent()));
             }
-
-
             mNotifyMgr.notify(notificationSet.getUniqueId(), mBuilder.build());
         }
     }

--- a/app/src/main/java/set/NotificationSet.java
+++ b/app/src/main/java/set/NotificationSet.java
@@ -17,16 +17,16 @@ public class NotificationSet implements RealmModel {
     private int bundleId;
     private String notifSummary;
     private String notifTitle;
-    private String notifContext;
+    private String notifContent;
 
     public NotificationSet() {
     }
 
-    public NotificationSet(int uniqueId, int bundleId, String notifTitle, String notifContext, String notifSummary) {
+    public NotificationSet(int uniqueId, int bundleId, String notifTitle, String notifContent, String notifSummary) {
         this.uniqueId = uniqueId;
         this.bundleId = bundleId;
         this.notifTitle = notifTitle;
-        this.notifContext = notifContext;
+        this.notifContent = notifContent;
         this.notifSummary = notifSummary;
     }
 
@@ -36,7 +36,7 @@ public class NotificationSet implements RealmModel {
     }
 
     public static NotificationSet createNotificationSet(Course course, Module module, Discussion discussion) {
-        return new NotificationSet(discussion.getId(), course.getId(), module.getName(), discussion.getName(), course.getShortname());
+        return new NotificationSet(discussion.getId(), course.getId(), module.getName(), discussion.getMessage(), course.getShortname());
     }
 
     public static NotificationSet createNotificationSet(int courseID, String courseName, int modId, String moduleName) {
@@ -72,18 +72,17 @@ public class NotificationSet implements RealmModel {
         this.notifTitle = notifTitle;
     }
 
-    public String getNotifContext() {
-        return notifContext;
+    public String getNotifContent() {
+        return notifContent;
     }
 
-    public void setNotifContext(String notifContext) {
-        this.notifContext = notifContext;
+    public void setNotifContent(String notifContent) {
+        this.notifContent = notifContent;
     }
 
     public void setUniqueId(int uniqueId) {
         this.uniqueId = uniqueId;
     }
-
 
     public String getTitle() {
         return notifSummary;
@@ -94,7 +93,4 @@ public class NotificationSet implements RealmModel {
 
     }
 
-    public String getContentText() {
-        return notifContext;
-    }
 }


### PR DESCRIPTION
Notifications summaries are no longer ugly, unparsed HTML strings.
Cleaned up the `NotificationSet` class as well.

Close #147