### PR TITLE
Fix empty ghost site notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Dates are in `yyyy-mm-dd`.
 
 
 ### Fixed
+* Empty ghost site notifications
 
 ## Version 1.6.0 (verCode 1060000), 2019-11-10
 ### Added

--- a/app/src/main/java/crux/bphc/cms/service/NotificationService.java
+++ b/app/src/main/java/crux/bphc/cms/service/NotificationService.java
@@ -208,7 +208,7 @@ public class NotificationService extends JobService {
             }
             List<Discussion> newDiscussions = courseDataHandler.setForumDiscussions(1, discussions);
             for (Discussion discussion : newDiscussions) {
-                createNotifModuleAdded(new NotificationSet(discussion.getId(), 1, "Site News", discussion.getMessage(), null));
+                createNotifModuleAdded(new NotificationSet(discussion.getId(), 1, "Site News", discussion.getMessage(), "Site News"));
             }
         }
 


### PR DESCRIPTION
Probably a Android quirk, but having a null notif summary creates an
empty ghost notification. Not sure if it's documented.

Closes #145