### PR TITLE
Fixed action bar title for announcements

### DIFF
--- a/app/src/main/java/crux/bphc/cms/fragments/ForumFragment.java
+++ b/app/src/main/java/crux/bphc/cms/fragments/ForumFragment.java
@@ -106,7 +106,7 @@ public class ForumFragment extends Fragment {
     @Override
     public void onStart() {
         if(getActivity() != null) {
-            getActivity().setTitle("Site News");
+            getActivity().setTitle(COURSE_NAME);
         }
         super.onStart();
     }


### PR DESCRIPTION
The action bar for fragment displaying announcements shows the course name as the title now.