### PR TITLE
Round More Options BottomSheetDialogFragment corners

### DIFF
--- a/app/src/main/java/crux/bphc/cms/fragments/MoreOptionsFragment.java
+++ b/app/src/main/java/crux/bphc/cms/fragments/MoreOptionsFragment.java
@@ -66,21 +66,10 @@ public class MoreOptionsFragment extends BottomSheetDialogFragment {
         }
     }
 
-    @Override
-    public void onActivityCreated(Bundle bundle) {
-        super.onActivityCreated(bundle);
-        getDialog().getWindow().getAttributes().windowAnimations = R.style.BottomSheetDialogAnimation;
-    }
-
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-        /*
-         * We `cloneInContext()` because (weirdly enough) the context of the inflater and `super.getContext()` are two
-         * different references. This means that the textview `R.id.more_options_header`'s textColor property wasn't
-         * being properly deferenced from the theme/style. This is probably a hacky fix, but it works.
-         */
-        return inflater.cloneInContext(getContext()).inflate(R.layout.fragment_more_options, container, false);
+        return inflater.inflate(R.layout.fragment_more_options, container, false);
     }
 
     @Override

--- a/app/src/main/res/layout/fragment_more_options.xml
+++ b/app/src/main/res/layout/fragment_more_options.xml
@@ -3,8 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:padding="10dp"
-    android:background="?cardBgColor">
+    android:padding="10dp">
 
     <TextView
         android:id="@+id/more_options_header"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.MaterialComponents.Light.DarkActionBar">
         <item name="colorPrimary">@color/orange</item>
         <item name="colorPrimaryDark">@color/orangeDark</item>
         <item name="colorAccent">@color/blueAccent</item>
@@ -16,8 +16,13 @@
         <item name="iconTintColor">@android:color/transparent</item> <!-- This is equivalent to no tint-->
         <item name="tokenImageTint">@android:color/transparent</item>
         <item name="cardBgColor">@color/cardBackgroundLight</item>
+        <item name="colorSurface">?attr/cardBgColor</item>
         <item name="dividerColor">@color/gray74</item>
+
+        <item name="bottomSheetDialogTheme">@style/CustomBottomSheetDialog</item>
     </style>
+
+
 
     <style name="AppTheme.Dark" parent="AppTheme">
         <item name="colorPrimary">@color/gray13</item>
@@ -68,10 +73,17 @@
 
     <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
 
-    <!-- BottomSheetDialog animation -->
-    <style name="BottomSheetDialogAnimation">
-        <item name="android:windowEnterAnimation">@anim/slide_up_bottom</item>
-        <item name="android:windowExitAnimation">@anim/slide_down_bottom</item>
+    <style name="CustomBottomSheetDialog" parent="ThemeOverlay.MaterialComponents.BottomSheetDialog">
+        <item name="bottomSheetStyle">@style/CustomBottomSheet</item>
     </style>
 
+    <style name="CustomBottomSheet" parent="Widget.MaterialComponents.BottomSheet.Modal">
+        <item name="shapeAppearanceOverlay">@style/CustomBottomSheetAppearance</item>
+    </style>
+
+    <style name="CustomBottomSheetAppearance" parent="">
+        <item name="cornerFamily">rounded</item>
+        <item name="cornerSizeTopRight">16dp</item>
+        <item name="cornerSizeTopLeft">16dp</item>
+    </style>
 </resources>


### PR DESCRIPTION
Apart from what the title says, this commit also changes the parent of
the `AppTheme` style. BottomSheetDialogFragment being a material class,
a couple of attributes needed to be set in our styles. These are set by
the new parent Material Components theme, removing the need for us to move
these our to our style. The lack of these would cause an InflateException
RTE.

This change also meant that the `onCreateView` inflater context jugaad
that was done in `MoreOptionsFragment` is no longer required. I still
have no clue why that was a problem to be begin with.

Overriding the default BottomSheetDialog themes also means that we don't
have to worry about animations in our code or styles.

This small change has resulted in a massive simplification of
our codebase and styles.