### PR TITLE
Empty course sections are now displayed

### DIFF
--- a/app/src/main/java/crux/bphc/cms/fragments/CourseSectionFragment.java
+++ b/app/src/main/java/crux/bphc/cms/fragments/CourseSectionFragment.java
@@ -253,7 +253,8 @@ public class CourseSectionFragment extends Fragment {
             return;
 
         if ((section.getModules() == null || section.getModules().isEmpty())
-                && (section.getSummary() == null || section.getSummary().isEmpty())) {
+                && (section.getSummary() == null || section.getSummary().isEmpty())
+                    && (section.getName().matches("Topic \\d+"))) {
             return;
         }
 


### PR DESCRIPTION
Course sections that have no module and no description are now
displayed. Default empty sections like Topic 1, Topic 2, etc are
not displayed.

close #100