### PR TITLE
Change action bar title for Course fragment

### DIFF
--- a/app/src/main/java/crux/bphc/cms/fragments/CourseSectionFragment.java
+++ b/app/src/main/java/crux/bphc/cms/fragments/CourseSectionFragment.java
@@ -103,6 +103,15 @@ public class CourseSectionFragment extends Fragment {
         setHasOptionsMenu(true);
     }
 
+    @Override
+    public void onStart() {
+        String title = courseDataHandler.getActionBarTitle(courseId);
+        if(getActivity() != null) {
+            getActivity().setTitle(title);
+        }
+        super.onStart();
+    }
+
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {

--- a/app/src/main/java/crux/bphc/cms/fragments/MyCoursesFragment.java
+++ b/app/src/main/java/crux/bphc/cms/fragments/MyCoursesFragment.java
@@ -478,7 +478,8 @@ public class MyCoursesFragment extends Fragment {
 
             void bind(Course course) {
                 courseName1.setText(course.getCourseName()[0]);
-                courseName2.setText(course.getCourseName()[1]);
+                String name = course.getCourseName()[1] + " " + course.getCourseName()[2];
+                courseName2.setText(name);
                 /*if (course.getDownloadStatus() == -1) {
                     progressBar.setVisibility(View.GONE);
                 } else {

--- a/app/src/main/java/helper/CourseDataHandler.java
+++ b/app/src/main/java/helper/CourseDataHandler.java
@@ -42,6 +42,15 @@ public class CourseDataHandler {
         return name;
     }
 
+    public String getActionBarTitle(int courseId){
+        Realm realm = Realm.getInstance(MyApplication.getRealmConfiguration());
+        Course course = realm.where(Course.class).equalTo("id", courseId).findFirst();
+        String title = course.getCourseName()[0] + " " + course.getCourseName()[2];
+        realm.close();
+        return title;
+
+    }
+
     private static <T> T deepCopy(T object, Class<T> type) {
         try {
             Gson gson = new Gson();

--- a/app/src/main/java/set/Course.java
+++ b/app/src/main/java/set/Course.java
@@ -2,6 +2,7 @@ package set;
 
 import android.text.Html;
 
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import io.realm.RealmObject;
@@ -113,22 +114,18 @@ public class Course extends RealmObject {
 
     public String[] getCourseName(){
         String courseName = getShortname();
-        String regex =  " ";    // Specifies the string pattern which is to be searched
-        Pattern pattern = Pattern.compile(regex , Pattern.CASE_INSENSITIVE);    // Used to perform case insensitive search of the string
-        String[] parts = pattern.split(courseName);
+        String regex =  "([\\w\\d \\-'&,]+ \\w\\d\\d\\d) ([\\w\\d \\-'&,]+) ([LTP]\\d*)";  // Specifies the string pattern which is to be searched
+        final Pattern pattern = Pattern.compile(regex, Pattern.MULTILINE);
+        final Matcher matcher = pattern.matcher(courseName);
+        String[] parts = {courseName , "" , ""};
 
-        String courseCode = parts[0] + " " + parts[1];
-        String name = "";
-        if(parts.length > 2) {
-            for (int i = 2; i < parts.length; i++) {
-                name = name + parts[i] + " ";
+        while (matcher.find()) {
+            for (int i = 1; i <= matcher.groupCount(); i++) {
+                parts[i-1] = matcher.group(i);
             }
         }
-        String[] result = new String[2];
-        result[0] = courseCode;
-        result[1] = name;
 
-        return result;
+        return parts;
 
     }
 


### PR DESCRIPTION
The title on the action bar for Course Section fragment is reduced to the course code and section number. For example, BIO F111 L1 instead of BIO F111 GENERAL BIOLOGY L1 that was shown earlier. The long course name on action bar got truncated and did not show the section number.
Also changed the regex used to split the course name.