### PR TITLE
Replace AlertDialog with MaterialAlertDialog and custom theme

### DIFF
--- a/app/src/main/java/crux/bphc/cms/MainActivity.java
+++ b/app/src/main/java/crux/bphc/cms/MainActivity.java
@@ -4,7 +4,6 @@ import android.Manifest;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
@@ -29,6 +28,7 @@ import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.navigation.NavigationView;
 
 import java.util.List;
@@ -243,32 +243,19 @@ public class MainActivity extends AppCompatActivity
             if (ActivityCompat.shouldShowRequestPermissionRationale(this,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
 
-                AlertDialog.Builder dialog;
-
-                if (MyApplication.getInstance().isDarkModeEnabled()) {
-                    dialog = new AlertDialog.Builder(this,R.style.Theme_AppCompat_Dialog_Alert);
-                } else {
-                    dialog = new AlertDialog.Builder(this,R.style.Theme_AppCompat_Light_Dialog_Alert);
-                }
-
-                dialog.setMessage("Need Write permissions to seamlessly Download Files...");
-                dialog.setPositiveButton("OK", new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialogInterface, int i) {
-                        ActivityCompat.requestPermissions(MainActivity.this,
-                                new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
-                                MY_PERMISSIONS_REQUEST_WRITE_STORAGE);
-                    }
-                });
-                dialog.show();
+                new MaterialAlertDialogBuilder(this)
+                        .setTitle("Permissions Request")
+                        .setMessage("Need Write Permissions to seamlessly Download Files...")
+                        .setPositiveButton("OK", (dialogInt, which) -> {
+                            ActivityCompat.requestPermissions(MainActivity.this,
+                                    new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
+                                    MY_PERMISSIONS_REQUEST_WRITE_STORAGE);
+                        }).show();
 
             } else {
-
-
                 ActivityCompat.requestPermissions(this,
                         new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
                         MY_PERMISSIONS_REQUEST_WRITE_STORAGE);
-
             }
         }
     }
@@ -298,28 +285,11 @@ public class MainActivity extends AppCompatActivity
 
 
     private AlertDialog askToLogout() {
-        AlertDialog.Builder alertDialog;
-
-        if (MyApplication.getInstance().isDarkModeEnabled()) {
-            alertDialog = new AlertDialog.Builder(MainActivity.this,R.style.Theme_AppCompat_Dialog_Alert);
-        } else {
-            alertDialog = new AlertDialog.Builder(MainActivity.this,R.style.Theme_AppCompat_Light_Dialog_Alert);
-        }
-
-        alertDialog.setMessage("Are you sure you want to Logout?");
-        alertDialog.setPositiveButton("OK", new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialogInterface, int i) {
-                logout();
-            }
-        });
-        alertDialog.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialogInterface, int i) {
-
-            }
-        });
-        return alertDialog.create();
+        MaterialAlertDialogBuilder dialog = new MaterialAlertDialogBuilder(this)
+                .setMessage("Are you sure you want to logout?")
+                .setPositiveButton("OK", (dialogInt, which) -> { logout(); })
+                .setNegativeButton("Cancel", (dialogInt, which) -> { });
+        return dialog.create();
     }
 
     public void logout() {

--- a/app/src/main/java/crux/bphc/cms/fragments/MyCoursesFragment.java
+++ b/app/src/main/java/crux/bphc/cms/fragments/MyCoursesFragment.java
@@ -2,7 +2,6 @@ package crux.bphc.cms.fragments;
 
 
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import android.text.Editable;
@@ -18,7 +17,6 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Observer;
@@ -27,11 +25,12 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import app.MyApplication;
 import crux.bphc.cms.CourseDetailActivity;
 import crux.bphc.cms.R;
 import helper.ClickListener;
@@ -457,7 +456,7 @@ public class MyCoursesFragment extends Fragment {
                         if (option == null) return;
                         switch (option.getId()) {
                             case 0:
-                                downloadCourse();
+                                confirmDownloadCourse();
                                 break;
 
                             case 1:
@@ -497,28 +496,20 @@ public class MyCoursesFragment extends Fragment {
                 unreadCount.setVisibility(count == 0 ? View.INVISIBLE : View.VISIBLE);
             }
 
-            public void downloadCourse(){
-                AlertDialog.Builder alertDialog;
-
-                if (MyApplication.getInstance().isDarkModeEnabled()) {
-                    alertDialog = new AlertDialog.Builder(getContext(),R.style.Theme_AppCompat_Dialog_Alert);
-                } else {
-                    alertDialog = new AlertDialog.Builder(getContext(),R.style.Theme_AppCompat_Light_Dialog_Alert);
-                }
-
-                alertDialog.setTitle("Confirm Download");
-                alertDialog.setMessage("Are you sure, you want to download the course?");
-                alertDialog.setPositiveButton("Yes", (dialogInterface, i) -> {
-                    if (downloadClickListener != null) {
-                        int pos = getLayoutPosition();
-                        if (!downloadClickListener.onClick(courses.get(pos), pos)) {
-                            Toast.makeText(getActivity(), "Download already in progress", Toast.LENGTH_SHORT).show();
-                        }
-                    }
-                });
-                alertDialog.setNegativeButton("Cancel", null);
-                alertDialog.show();
-
+            void confirmDownloadCourse() {
+                new MaterialAlertDialogBuilder(context)
+                        .setTitle("Confirm Download")
+                        .setMessage("Are you sure you want to all the contents of this course?")
+                        .setPositiveButton("Yes", (dialogInterface, i) -> {
+                            if (downloadClickListener != null) {
+                                int pos = getLayoutPosition();
+                                if (!downloadClickListener.onClick(courses.get(pos), pos)) {
+                                    Toast.makeText(getActivity(), "Download already in progress", Toast.LENGTH_SHORT).show();
+                                }
+                            }
+                         })
+                        .setNegativeButton("Cancel", null)
+                        .show();
             }
 
             public void markAllAsRead(int position){

--- a/app/src/main/java/helper/Util.java
+++ b/app/src/main/java/helper/Util.java
@@ -4,6 +4,8 @@ import android.content.Context;
 
 import androidx.appcompat.app.AlertDialog;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
@@ -137,11 +139,11 @@ public class Util {
     }
 
     public static void showBadTokenDialog(Context ctxt) {
-        AlertDialog.Builder dlgAlert  = new AlertDialog.Builder(ctxt);
-        dlgAlert.setMessage("The login failed due to an invalid token. Please ensure" +
-                " that you are logged into your BITS Email on your default browser.");
-        dlgAlert.setTitle("Invalid Token");
-        dlgAlert.setPositiveButton("OK", null);
-        dlgAlert.create().show();
+        new MaterialAlertDialogBuilder(ctxt)
+            .setMessage("The login failed due to an invalid token. Please ensure" +
+                        " that you are logged into your BITS Email on your default browser.")
+            .setTitle("Invalid Token")
+            .setPositiveButton("OK", null)
+            .show();
     }
 }

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -10,5 +10,6 @@
         <attr name="unReadModule" format="reference" />
         <attr name="tokenImageTint" format="reference" />
         <attr name="dividerColor" format="reference" />
+        <attr name="textButtonColor" format="reference" />
     </declare-styleable>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -7,7 +7,7 @@
         <item name="colorAccent">@color/blueAccent</item>
         <item name="android:textColorPrimary">@color/text_primary_light</item>
         <item name="android:textColorSecondary">@color/text_secondary_light</item>
-        <item name="dialogTheme">@style/AlertDialog.AppCompat.Light</item>
+        <item name="textButtonColor">@color/orange</item>
 
         <item name="themeBackground">@color/activityBackgroundLight</item>
         <item name="navBarColorStates">@color/navbar_itemcolor_light</item>
@@ -21,16 +21,15 @@
         <item name="dividerColor">@color/gray74</item>
 
         <item name="bottomSheetDialogTheme">@style/CustomBottomSheetDialog</item>
+        <item name="materialAlertDialogTheme">@style/AlertDialogMaterialTheme</item>
     </style>
-
-
 
     <style name="AppTheme.Dark" parent="AppTheme">
         <item name="colorPrimary">@color/gray13</item>
         <item name="colorPrimaryDark">@color/black</item>
         <item name="android:textColorPrimary">@color/text_primary_dark</item>
         <item name="android:textColorSecondary">@color/text_secondary_dark</item>
-        <item name="dialogTheme">@style/AlertDialog.AppCompat</item>
+        <item name="textButtonColor">@color/orange</item>
 
         <item name="themeBackground">@color/activityBackgroundDark</item>
         <item name="navBarColorStates">@color/navbar_itemcolor_dark</item>
@@ -41,6 +40,8 @@
         <item name="iconTintColor">@color/white</item>
         <item name="tokenImageTint">@color/black_alpha26</item>
         <item name="dividerColor">@color/gray26</item>
+
+        <item name="materialAlertDialogTheme">@style/AlertDialogMaterialTheme</item>
     </style>
 
     <style name="SplashTheme" parent="AppTheme.Dark">
@@ -75,6 +76,7 @@
 
     <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
 
+    <!-- Custom BottomSheetDialog theme -->
     <style name="CustomBottomSheetDialog" parent="ThemeOverlay.MaterialComponents.BottomSheetDialog">
         <item name="bottomSheetStyle">@style/CustomBottomSheet</item>
     </style>
@@ -87,5 +89,35 @@
         <item name="cornerFamily">rounded</item>
         <item name="cornerSizeTopRight">16dp</item>
         <item name="cornerSizeTopLeft">16dp</item>
+    </style>
+
+    <!-- Custom Alert Dialog Theme -->
+    <style name="AlertDialogMaterialTheme" parent="ThemeOverlay.MaterialComponents.MaterialAlertDialog">
+        <item name ="materialAlertDialogTitleTextStyle">@style/AlertDialog.Title.Text</item>
+        <item name="materialAlertDialogBodyTextStyle">@style/AlertDialog.Body.Text</item>
+        <item name="buttonBarPositiveButtonStyle">@style/AlertDialog.Button.Positive</item>
+        <item name="buttonBarNegativeButtonStyle">@style/AlertDialog.Button.Negative</item>
+    </style>
+
+    <style name="AlertDialog.Title.Text" parent="MaterialAlertDialog.MaterialComponents.Title.Text">
+        <item name="android:textSize">18sp</item>
+        <item name="android:textColor">?android:textColorPrimary</item>
+    </style>
+
+    <style name="AlertDialog.Body.Text" parent="TextAppearance.MaterialComponents.Body2">
+        <item name="android:textSize">16sp</item>
+        <item name="android:textColor">?android:textColorPrimary</item>
+    </style>
+
+    <style name="AlertDialog.Button.Positive" parent="Widget.MaterialComponents.Button.TextButton">
+        <item name="android:textColor">?textButtonColor</item>1
+        <item name="android:textAllCaps">false</item>
+        <item name="android:textSize">14sp</item>
+    </style>
+
+    <style name="AlertDialog.Button.Negative" parent="Widget.MaterialComponents.Button.TextButton">
+        <item name="android:textColor">?textButtonColor</item>1
+        <item name="android:textAllCaps">false</item>
+        <item name="android:textSize">14sp</item>
     </style>
 </resources>


### PR DESCRIPTION
The move to material theme as the parent of `AppTheme` (`1b506ee624`)
meant that `AlertDialog`s buttons were broken. This replaces
AlertDialogs that utilize buttons with a MaterialAlertDialog.