### PR TITLE
Fix: Read/Unread Module Visual Bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ Dates are in `yyyy-mm-dd`.
 ## Changed
 
 ## Fixed
-* Full Course Names not being displayed (regression from **v1.7.0-beta1**)
-
+* Full Course Names not being displayed (regression in **v1.7.0-beta1**)
+* Module Read/Unread Visual Bug (regression in **v1.7.0-beta1**)
 ## Version 1.7.0-beta.1 (verCode 1070001), 2020-05-09
 ### Added
 * Dialogbox on invalid token after Google login

--- a/app/src/main/java/crux/bphc/cms/helper/ModulesAdapter.java
+++ b/app/src/main/java/crux/bphc/cms/helper/ModulesAdapter.java
@@ -251,11 +251,10 @@ public class ModulesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                 TypedValue value = new TypedValue();
                 context.getTheme().resolveAttribute(R.attr.unReadModule,value,true);
                 textWrapper.setBackgroundColor(value.data);
-            }
-            else {
+            } else {
                 TypedValue value = new TypedValue();
                 context.getTheme().resolveAttribute(R.attr.cardBgColor,value,true);
-                cardView.setCardBackgroundColor(value.data);
+                textWrapper.setBackgroundColor(value.data);
             }
 
             name.setText(module.getName());


### PR DESCRIPTION
Regression in `35484fdc`.

Modules would visually look like read/unread when the more options
ellipsis button is used. However, the internal state (`isNewContent`)
doesn't change.

Closes #196