### PR TITLE
Fix: Lint issues that weren't caught in c20c0e4

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
          SharedPreference data isn't particular useful for a backup either.-->
     <application
         android:name="crux.bphc.cms.app.MyApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_blue_launcher_app_icon"
         android:label="@string/app_name"
         android:supportsRtl="true"

--- a/app/src/main/res/layout/row_course.xml
+++ b/app/src/main/res/layout/row_course.xml
@@ -101,7 +101,7 @@
                 android:padding="2dp"
                 android:clickable="true"
                 android:focusable="true"
-                android:tint="#FF808080"
+                app:tint="#FF808080"
                 app:srcCompat="@drawable/star"
                 android:contentDescription="@string/favorite"
 


### PR DESCRIPTION
No idea why the lint issues weren't caught when c20c0e4 was pushed. They aren't being caught locally either. 