### PR TITLE
Make dynamic TextViews selectable

### DIFF
--- a/app/src/main/java/crux/bphc/cms/adapters/delegates/CourseSectionDelegate.java
+++ b/app/src/main/java/crux/bphc/cms/adapters/delegates/CourseSectionDelegate.java
@@ -18,6 +18,7 @@ import java.util.List;
 import crux.bphc.cms.R;
 import crux.bphc.cms.interfaces.CourseContent;
 import crux.bphc.cms.models.course.CourseSection;
+import crux.bphc.cms.utils.Utils;
 import crux.bphc.cms.widgets.CollapsibleTextView;
 
 /**
@@ -56,8 +57,8 @@ public class CourseSectionDelegate extends AdapterDelegate<List<CourseContent>> 
         vh.sectionName.setText(section.getName());
         if (!section.getSummary().isEmpty()) {
             vh.sectionDescription.setVisibility(View.VISIBLE);
-            vh.sectionDescription.setFullText(HtmlCompat.fromHtml(section.getSummary(),
-                    HtmlCompat.FROM_HTML_MODE_COMPACT));
+            vh.sectionDescription.setFullText(Utils.trimWhiteSpace(HtmlCompat.fromHtml(section.getSummary().trim(),
+                    HtmlCompat.FROM_HTML_MODE_COMPACT)));
             vh.sectionDescription.setMovementMethod(LinkMovementMethod.getInstance());
         } else {
             vh.sectionDescription.setVisibility(View.GONE);

--- a/app/src/main/java/crux/bphc/cms/utils/Utils.java
+++ b/app/src/main/java/crux/bphc/cms/utils/Utils.java
@@ -8,6 +8,8 @@ import android.net.Uri;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
@@ -121,5 +123,31 @@ public class Utils {
         Intent intent = new Intent(Intent.ACTION_VIEW);
         intent.setData(Uri.parse(url));
         activity.startActivity(intent);
+    }
+
+    /** Trim trailing and leading whitespace as defined by {@link
+     * Character#isWhitespace}.
+     * @return Empty string is source is null, otherwise string with all trailing
+     *         whitespace removed
+     */
+    @NotNull
+    public static CharSequence trimWhiteSpace(CharSequence source) {
+        if (source == null) return "";
+
+        // loop to the first non-white space from the back
+        int i = source.length();
+        do {
+            --i;
+        } while (Character.isWhitespace(source.charAt(i)));
+        int end = i + 1;
+
+        // loop to the first non-white space from the front
+        i = 0;
+        while(Character.isWhitespace(source.charAt(i))) {
+            ++i;
+        }
+        int begin = i;
+
+        return source.subSequence(begin, end);
     }
 }

--- a/app/src/main/java/crux/bphc/cms/widgets/CollapsibleTextView.java
+++ b/app/src/main/java/crux/bphc/cms/widgets/CollapsibleTextView.java
@@ -12,6 +12,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import crux.bphc.cms.R;
+import crux.bphc.cms.utils.Utils;
 
 /**
  * A user interface element that can be collapsed on user input using a
@@ -84,16 +85,15 @@ public class CollapsibleTextView extends androidx.appcompat.widget.AppCompatText
             if (layout.getLineCount() > collapsedLineCount) {
                 textToShow = fullText.subSequence(0, layout.getLineEnd(collapsedLineCount - 1));
 
-                spanBuilder.append(textToShow);
-                if (spanBuilder.charAt(spanBuilder.length() - 1) != '\n') {
-                    spanBuilder.append("\n");
-                }
+                spanBuilder.append(Utils.trimWhiteSpace(textToShow));
+                spanBuilder.append("\n");
                 spanBuilder.append(expandText);
                 spanBuilder.setSpan(new ClickableSpan() {
                     @Override
                     public void onClick(@NonNull View widget) {
                         state = TextState.EXPANDED;
                         requestLayout();
+                        shouldRemeasure = true;
                     }
                 }, spanBuilder.length() - expandText.length() - 1, spanBuilder.length(), 0);
             } else {
@@ -114,6 +114,7 @@ public class CollapsibleTextView extends androidx.appcompat.widget.AppCompatText
                     public void onClick(@NonNull View widget) {
                         state = TextState.COLLAPSED;
                         requestLayout();
+                        shouldRemeasure = true;
                     }
                 }, spanBuilder.length() - collapseText.length() - 1, spanBuilder.length(), 0);
             } else {
@@ -125,7 +126,6 @@ public class CollapsibleTextView extends androidx.appcompat.widget.AppCompatText
         // Have the layout measure itself once more
         super.setText(spanBuilder);
         measure(widthMeasureSpec, heightMeasureSpec);
-        shouldRemeasure = true; // The next time this method is called, we remeasure
     }
 
     public void setFullText(CharSequence fullText) {

--- a/app/src/main/res/layout/fragment_discussion.xml
+++ b/app/src/main/res/layout/fragment_discussion.xml
@@ -46,6 +46,7 @@
                     android:textColor="?android:textColorPrimary"
                     android:textSize="20sp"
                     android:textStyle="bold"
+                    android:textIsSelectable="true"
 
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="@id/barrier_profile_pic"
@@ -105,6 +106,7 @@
                     android:text="@string/lorem"
                     android:textColor="?android:textColorPrimary"
                     android:textSize="16sp"
+                    android:textIsSelectable="true"
 
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/row_course_module.xml
+++ b/app/src/main/res/layout/row_course_module.xml
@@ -27,11 +27,11 @@
             android:layout_marginTop="8dp"
             android:layout_marginBottom="8dp"
             android:contentDescription="@null"
-            app:layout_constraintBottom_toTopOf="@id/nameAndDescriptionDivider"
 
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="@drawable/file_powerpoint" />
+            app:srcCompat="@drawable/file_powerpoint"
+            app:layout_constraintBottom_toTopOf="@id/name_description_barrier" />
 
         <ProgressBar
             android:id="@+id/progress_bar"
@@ -43,9 +43,9 @@
             android:layout_marginBottom="8dp"
             android:visibility="gone"
 
-            app:layout_constraintBottom_toTopOf="@id/nameAndDescriptionDivider"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/name_description_barrier" />
 
         <crux.bphc.cms.widgets.HtmlTextView
             android:id="@+id/name"
@@ -62,7 +62,8 @@
 
             app:layout_constraintEnd_toStartOf="@id/download"
             app:layout_constraintStart_toEndOf="@id/icon_barrier"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/name_description_barrier" />
 
         <ImageView
             android:id="@+id/download"
@@ -72,11 +73,11 @@
             android:layout_margin="14dp"
             android:contentDescription="@string/download_go"
             app:tint="?iconTintColor"
-            app:layout_constraintBottom_toTopOf="@id/nameAndDescriptionDivider"
+            app:srcCompat="@drawable/download"
 
             app:layout_constraintEnd_toStartOf="@id/more"
             app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="@drawable/download" />
+            app:layout_constraintBottom_toTopOf="@id/name_description_barrier" />
 
         <View
             android:id="@+id/click_wrapper"
@@ -101,12 +102,11 @@
             android:contentDescription="@string/more_options_btn"
             android:focusable="true"
             app:tint="?iconTintColor"
-            app:layout_constraintBottom_toTopOf="@id/nameAndDescriptionDivider"
+            app:srcCompat="@drawable/dots_horizontal"
 
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="@drawable/dots_horizontal" />
-
+            app:layout_constraintBottom_toTopOf="@id/name_description_barrier" />
 
         <View
             android:id="@+id/nameAndDescriptionDivider"
@@ -130,6 +130,7 @@
             android:paddingEnd="8dp"
             android:text="@string/lorem"
             android:textColor="?android:textColorSecondary"
+            android:textIsSelectable="true"
 
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.0"

--- a/app/src/main/res/layout/row_course_section.xml
+++ b/app/src/main/res/layout/row_course_section.xml
@@ -30,6 +30,7 @@
         android:textColor="?android:textColorPrimary"
         android:textSize="18sp"
         android:textStyle="bold"
+        android:textIsSelectable="true"
 
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toEndOf="@id/section_name_margin"
@@ -61,6 +62,7 @@
         android:textColor="?android:textColorPrimary"
         android:textSize="16sp"
         android:textStyle="italic"
+        android:textIsSelectable="true"
         android:visibility="visible"
 
         app:layout_constraintTop_toBottomOf="@id/section_name"

--- a/app/src/main/res/layout/row_forum.xml
+++ b/app/src/main/res/layout/row_forum.xml
@@ -43,6 +43,7 @@
                 android:textColor="?android:textColorPrimary"
                 android:textSize="16sp"
                 android:textStyle="bold"
+                android:textIsSelectable="true"
 
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
@@ -105,6 +106,7 @@
                 android:text="@string/lorem"
                 android:textColor="?android:textColorSecondary"
                 android:textSize="12sp"
+                android:textIsSelectable="true"
 
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="@id/user_pic"


### PR DESCRIPTION
TextViews like Course Section descriptions, announcements etc are not
selectable. This will allow users to copy text (including links) which
may otherwise not be clickable (due to non-existent anchor tags).

This commit also introduced a trim function for character sequences to
get rid of leading and trailing CollapsibleTextViews as well as
centering elements in `row_course_module`.