### PR TITLE
Fix: App crash when whitespace only string to trimWhiteSpace

### DIFF
--- a/app/src/main/java/crux/bphc/cms/adapters/delegates/CourseSectionDelegate.java
+++ b/app/src/main/java/crux/bphc/cms/adapters/delegates/CourseSectionDelegate.java
@@ -1,6 +1,7 @@
 package crux.bphc.cms.adapters.delegates;
 
 import android.app.Activity;
+import android.text.Html;
 import android.text.method.LinkMovementMethod;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -55,10 +56,11 @@ public class CourseSectionDelegate extends AdapterDelegate<List<CourseContent>> 
         CourseSection section = (CourseSection) items.get(position);
 
         vh.sectionName.setText(section.getName());
-        if (!section.getSummary().isEmpty()) {
+        CharSequence summary = Utils.trimWhiteSpace(HtmlCompat.fromHtml(section.getSummary().trim(),
+                HtmlCompat.FROM_HTML_MODE_COMPACT));
+        if (summary.length() != 0) {
             vh.sectionDescription.setVisibility(View.VISIBLE);
-            vh.sectionDescription.setFullText(Utils.trimWhiteSpace(HtmlCompat.fromHtml(section.getSummary().trim(),
-                    HtmlCompat.FROM_HTML_MODE_COMPACT)));
+            vh.sectionDescription.setFullText(summary);
             vh.sectionDescription.setMovementMethod(LinkMovementMethod.getInstance());
         } else {
             vh.sectionDescription.setVisibility(View.GONE);

--- a/app/src/main/java/crux/bphc/cms/utils/Utils.java
+++ b/app/src/main/java/crux/bphc/cms/utils/Utils.java
@@ -138,16 +138,17 @@ public class Utils {
         int i = source.length();
         do {
             --i;
-        } while (Character.isWhitespace(source.charAt(i)));
+        } while (i >= 0 && Character.isWhitespace(source.charAt(i)));
         int end = i + 1;
 
         // loop to the first non-white space from the front
         i = 0;
-        while(Character.isWhitespace(source.charAt(i))) {
+        while(i < source.length() && Character.isWhitespace(source.charAt(i))) {
             ++i;
         }
         int begin = i;
 
+        if (begin >= 0 && end < source.length() && begin > end) return "";
         return source.subSequence(begin, end);
     }
 }


### PR DESCRIPTION
This patch also checks to see if the summary of a course section is
empty HTML parsing and trimming instead of before. This prevents course
sections with no string from being visible.

Close #242