### PR TITLE
Fix infinite loop in 'resolve()'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Dates are in `yyyy-mm-dd`.
 ### Changed
 
 ### Fixed
+* Potential infinite loop when resolving files with the same name
 
 ## Version 1.7.0-beta.2 (verCode 1070002), 2020-08-20
 

--- a/app/src/main/java/crux/bphc/cms/helper/CourseRequestHandler.java
+++ b/app/src/main/java/crux/bphc/cms/helper/CourseRequestHandler.java
@@ -256,24 +256,29 @@ public class CourseRequestHandler {
     private void changeName(Content content) {
         String fileName = content.getFileName();
         String newFileName = fileName;
-        //Makes sure that the string fileName contains an extension
-        if (!(fileName.lastIndexOf('.') == -1)) {
-            int lastIndex = fileName.lastIndexOf('(');
-            //if '(' is not there in the fileName adds '(1)' else increments the value in the brackets.
-            if (lastIndex == -1) {
-                newFileName = fileName.substring(0, fileName.lastIndexOf('.')) +
-                        "(1)" +
-                        fileName.substring(fileName.lastIndexOf('.'));
+
+        // new file name will be of the format <original>(count)[.ext]
+        int lastIndex = fileName.lastIndexOf('(');
+        boolean countUpdated = false;
+        if (lastIndex != -1) {
+            String fileNum = fileName.substring(lastIndex + 1, fileName.lastIndexOf(')'));
+            try {
+                int count = Integer.parseInt(fileNum);
+                newFileName = fileName.substring(0, lastIndex + 1)
+                        + ++count
+                        + fileName.substring(fileName.lastIndexOf(')'));
+                countUpdated = true;
+            } catch (NumberFormatException e) {
+            }
+        }
+
+        if (!countUpdated) {
+            int extension = fileName.lastIndexOf('.');
+            if (extension != -1) {
+                newFileName = fileName.substring(0, extension) + "(1)" +
+                        fileName.substring(extension);
             } else {
-                String fileNum = fileName.substring(lastIndex + 1, fileName.lastIndexOf(')'));
-                try {
-                    int count = Integer.parseInt(fileNum);
-                    newFileName = fileName.substring(0, lastIndex + 1) +
-                            ++count +
-                            fileName.substring(fileName.lastIndexOf(')'));
-                } catch (NumberFormatException e) {
-                    newFileName = fileName;
-                }
+                newFileName = fileName + "(1)";
             }
         }
         content.setFileName(newFileName);


### PR DESCRIPTION
`resolve()` in keeps calling changeName until a new unique filename
has been set by the `changeName()`. However `changeName()` does nothing to
files that have no extensions or those that have extensions with strings
between paranthesis. This causes an infinte loop.

Close #246