### PR TITLE
Switch to Glide from Picasso, fix loading remote SVGs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Dates are in `yyyy-mm-dd`.
 ### Fixed
 * Potential infinite loop when resolving files with the same name
 * Potential ANR when updating a large number of courses
+* Infinite loading animation for modules with SVG icons
 
 ## Version 1.7.0-beta.2 (verCode 1070002), 2020-08-20
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,10 +72,13 @@ dependencies {
     // Network requests library
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
-    implementation 'com.squareup.okhttp3:logging-interceptor:4.8.1'
     // for logging
-    // Image downloading and caching library
-    implementation 'com.squareup.picasso:picasso:2.71828'
+    implementation 'com.squareup.okhttp3:logging-interceptor:4.8.1'
+    // SVG parsing library
+    implementation 'com.caverock:androidsvg-aar:1.4'
+    // Image loading and caching library
+    implementation 'com.github.bumptech.glide:glide:4.11.0'
+    kapt 'com.github.bumptech.glide:compiler:4.11.0'
     // Resources dependency injection
     implementation 'com.jakewharton:butterknife:10.2.3'
     annotationProcessor 'com.jakewharton:butterknife-compiler:10.2.3'

--- a/app/src/main/java/crux/bphc/cms/adapters/delegates/CourseModuleDelegate.java
+++ b/app/src/main/java/crux/bphc/cms/adapters/delegates/CourseModuleDelegate.java
@@ -1,6 +1,7 @@
 package crux.bphc.cms.adapters.delegates;
 
 import android.app.Activity;
+import android.net.Uri;
 import android.text.SpannableStringBuilder;
 import android.text.method.LinkMovementMethod;
 import android.util.TypedValue;
@@ -9,24 +10,29 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.core.text.HtmlCompat;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.load.DataSource;
+import com.bumptech.glide.load.engine.GlideException;
+import com.bumptech.glide.request.RequestListener;
+import com.bumptech.glide.request.target.Target;
 import com.hannesdorfmann.adapterdelegates4.AdapterDelegate;
-import com.squareup.picasso.Callback;
-import com.squareup.picasso.Picasso;
 
 import java.util.List;
 
 import crux.bphc.cms.R;
 import crux.bphc.cms.interfaces.ClickListener;
-import crux.bphc.cms.io.FileManager;
-import crux.bphc.cms.widgets.HtmlTextView;
 import crux.bphc.cms.interfaces.CourseContent;
+import crux.bphc.cms.io.FileManager;
 import crux.bphc.cms.models.course.Module;
 import crux.bphc.cms.widgets.CollapsibleTextView;
+import crux.bphc.cms.widgets.HtmlTextView;
 
 /**
  * Adapter delegate for course modules.
@@ -117,18 +123,24 @@ public class CourseModuleDelegate extends AdapterDelegate<List<CourseContent>> {
             vh.modIcon.setVisibility(View.GONE);
             if (module.getModType() != Module.Type.LABEL) {
                 vh.progressBar.setVisibility(View.VISIBLE);
-                Picasso.get().load(module.getModIcon()).into(vh.modIcon, new Callback() {
+                Glide.with(vh.modIcon.getContext()).addDefaultRequestListener(new RequestListener<Object>() {
                     @Override
-                    public void onSuccess() {
+                    public boolean onLoadFailed(@Nullable GlideException e, Object model,
+                                                Target<Object> target, boolean isFirstResource) {
+                        Toast.makeText(vh.modIcon.getContext(), String.format("Load failed for %s",
+                                module.getModIcon()), Toast.LENGTH_SHORT).show();
+                        return false;
+                    }
+
+                    @Override
+                    public boolean onResourceReady(Object resource, Object model,
+                                                   Target<Object> target, DataSource dataSource,
+                                                   boolean isFirstResource) {
                         vh.progressBar.setVisibility(View.GONE);
                         vh.modIcon.setVisibility(View.VISIBLE);
+                        return false;
                     }
-
-                    @Override
-                    public void onError(Exception e) {
-
-                    }
-                });
+                }).load(Uri.parse(module.getModIcon())).into(vh.modIcon);
             }
         }
 

--- a/app/src/main/java/crux/bphc/cms/fragments/DiscussionFragment.java
+++ b/app/src/main/java/crux/bphc/cms/fragments/DiscussionFragment.java
@@ -16,7 +16,7 @@ import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
 
-import com.squareup.picasso.Picasso;
+import com.bumptech.glide.Glide;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -114,7 +114,7 @@ public class DiscussionFragment extends Fragment {
                 }
             });
 
-            Picasso.get().load(discussion.getUserPictureUrl()).into(mUserPic);
+            Glide.with(requireContext()).load(discussion.getUserPictureUrl()).into(mUserPic);
 
             mSubject.setText(discussion.getSubject());
             mUserName.setText(discussion.getUserFullName());

--- a/app/src/main/java/crux/bphc/cms/fragments/ForumFragment.java
+++ b/app/src/main/java/crux/bphc/cms/fragments/ForumFragment.java
@@ -17,7 +17,7 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
-import com.squareup.picasso.Picasso;
+import com.bumptech.glide.Glide;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -273,7 +273,7 @@ public class ForumFragment extends Fragment {
             }
 
             public void bind(Discussion discussion) {
-                Picasso.get().load(discussion.getUserPictureUrl()).into(mUserPic);
+                Glide.with(mUserPic.getContext()).load(discussion.getUserPictureUrl()).into(mUserPic);
                 mSubject.setText(discussion.getSubject());
                 mUserName.setText(discussion.getUserFullName());
                 mModifiedTime.setText(formatDate(discussion.getTimeModified()));

--- a/app/src/main/java/crux/bphc/cms/glide/SvgDecoder.kt
+++ b/app/src/main/java/crux/bphc/cms/glide/SvgDecoder.kt
@@ -1,0 +1,29 @@
+package crux.bphc.cms.glide
+
+import com.bumptech.glide.load.Options
+import com.bumptech.glide.load.ResourceDecoder
+import com.bumptech.glide.load.engine.Resource
+import com.bumptech.glide.load.resource.SimpleResource
+import com.caverock.androidsvg.SVG
+import com.caverock.androidsvg.SVGParseException
+import java.io.InputStream
+
+
+/**
+ * Attempts to decode an {@link InputStream} to an Glide internal representation.
+ */
+class SvgDecoder : ResourceDecoder<InputStream?, SVG?> {
+    override fun handles(source: InputStream, options: Options): Boolean {
+        return true // Assume we can decode an input stream, can't attempt a decode here
+    }
+
+    override fun decode(source: InputStream, width: Int, height: Int, options: Options):
+            Resource<SVG?>? {
+        return try {
+            val svg = SVG.getFromInputStream(source)
+            SimpleResource(svg)
+        } catch (ex: SVGParseException) {
+            return null; // We can't handle it, might not be an svg
+        }
+    }
+}

--- a/app/src/main/java/crux/bphc/cms/glide/SvgDrawableTranscoder.kt
+++ b/app/src/main/java/crux/bphc/cms/glide/SvgDrawableTranscoder.kt
@@ -1,0 +1,20 @@
+package crux.bphc.cms.glide
+
+import android.graphics.drawable.PictureDrawable
+import com.bumptech.glide.load.Options
+import com.bumptech.glide.load.engine.Resource
+import com.bumptech.glide.load.resource.SimpleResource
+import com.bumptech.glide.load.resource.transcode.ResourceTranscoder
+import com.caverock.androidsvg.SVG
+
+/**
+ * Transcodes the Svg image to an Android Vector Resource with the help of AndroidSVG.
+ */
+class SvgDrawableTranscoder : ResourceTranscoder<SVG?, PictureDrawable?> {
+    override fun transcode(toTranscode: Resource<SVG?>, options: Options): Resource<PictureDrawable?>? {
+        val svg = toTranscode.get()
+        val picture = svg.renderToPicture()
+        val drawable = PictureDrawable(picture)
+        return SimpleResource(drawable)
+    }
+}

--- a/app/src/main/java/crux/bphc/cms/glide/SvgModule.kt
+++ b/app/src/main/java/crux/bphc/cms/glide/SvgModule.kt
@@ -1,0 +1,27 @@
+package crux.bphc.cms.glide
+
+import android.content.Context
+import android.graphics.drawable.PictureDrawable
+import com.bumptech.glide.Glide
+import com.bumptech.glide.Registry
+import com.bumptech.glide.annotation.GlideModule
+import com.bumptech.glide.module.AppGlideModule
+import com.caverock.androidsvg.SVG
+import java.io.InputStream
+
+/**
+ * An Svg Module for Glide that uses AndroidSVG to parse SVG images.
+ */
+@GlideModule
+class SvgModule : AppGlideModule() {
+
+    override fun registerComponents(context: Context, glide: Glide, registry: Registry) {
+        registry.register(SVG::class.java, PictureDrawable::class.java, SvgDrawableTranscoder())
+                .append(InputStream::class.java, SVG::class.java, SvgDecoder());
+    }
+
+    override fun isManifestParsingEnabled(): Boolean {
+        return false
+    }
+
+}


### PR DESCRIPTION
Neither Glide nor Picasso has builtin support for decoding SVGs and
displaying them in ImagesViews. However, Glide's API allows for
specifying custom decoders. Glide fetches the SVG and delgates through
our pipeline to AndroidSVG for decoding. Glide also handles caching
SVGs. And, most importantly, loading raster images works just like it
used to with Picasso.

Close #127