### PR TITLE
Fix: Downloadable modules no longer downloadable

### DIFF
--- a/app/src/main/java/crux/bphc/cms/models/course/Module.kt
+++ b/app/src/main/java/crux/bphc/cms/models/course/Module.kt
@@ -44,7 +44,7 @@ open class Module(
         }
 
     val isDownloadable: Boolean
-        get() = contents.isEmpty() && modType !in arrayOf(Type.URL, Type.FORUM, Type.PAGE)
+        get() = contents.isNotEmpty() && modType !in arrayOf(Type.URL, Type.FORUM, Type.PAGE)
 
     val moduleIcon: Int
         get() {


### PR DESCRIPTION
Modules which had contents (for eg. Resource modules) weren't
downloadable. Bug Introduced in
`8a0a85b1b581906b5fc0f2d762249e4d7399f1e7`