### PR TITLE
Fix title of more option bottom sheet for courses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Dates are in `yyyy-mm-dd`.
 
 ### Fixed
 * Unparsed HTML entities in Discussion notifications
+* Wrong course name in bottomsheet title
 
 ## Version 1.7.0 (verCode 1070003), 2020-10-13
 

--- a/app/src/main/java/crux/bphc/cms/fragments/MyCoursesFragment.kt
+++ b/app/src/main/java/crux/bphc/cms/fragments/MyCoursesFragment.kt
@@ -430,7 +430,7 @@ class MyCoursesFragment : Fragment() {
                         moreOptionsViewModel.selection.removeObservers((context as AppCompatActivity))
                         moreOptionsViewModel.clearSelection()
                     }
-                    val courseName = this@MyCoursesFragment.courses[layoutPosition].shortName
+                    val courseName = this@Adapter.courses[layoutPosition].shortName
                     val moreOptionsFragment = MoreOptionsFragment.newInstance(courseName, options)
                     moreOptionsFragment.show((context as AppCompatActivity).supportFragmentManager, moreOptionsFragment.tag)
                     moreOptionsViewModel.selection.observe(context, observer)


### PR DESCRIPTION
Changed the course list being used to get the title course name, from the 'courses' list of MyCourseFragment class to the 'courses' declared inside the Adapter class. The latter is the list which is sorted and displayed.

Fixes #264