### PR TITLE
Update UI for mark as read/unread option in bottom sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Dates are in `yyyy-mm-dd`.
 * Unparsed HTML entities in Discussion notifications
 * Wrong course name in bottomsheet title
 * Unimplemented module types launch module URL in browser
+* UI not updating on marking course as read
 
 ## Version 1.7.0 (verCode 1070003), 2020-10-13
 

--- a/app/src/main/java/crux/bphc/cms/fragments/CourseContentFragment.java
+++ b/app/src/main/java/crux/bphc/cms/fragments/CourseContentFragment.java
@@ -256,6 +256,7 @@ public class CourseContentFragment extends Fragment {
                             break;
                         case 2:
                             courseDataHandler.markModuleAsReadOrUnread(module, true);
+                            adapter.notifyItemChanged(position);
                             break;
                         case 3:
                             if (content != null && activity != null) {

--- a/app/src/main/java/crux/bphc/cms/fragments/MyCoursesFragment.kt
+++ b/app/src/main/java/crux/bphc/cms/fragments/MyCoursesFragment.kt
@@ -380,16 +380,14 @@ class MyCoursesFragment : Fragment() {
                         .show()
             }
 
-            fun markAllAsRead(position: Int) {
-                val courseId = this@MyCoursesFragment.courses[position].id
+            fun markAllAsRead() {
+                val courseId = courses[layoutPosition].id
                 val courseSections: List<CourseSection>
 
                 courseSections = courseDataHandler.getCourseData(courseId)
                 courseDataHandler.markAllAsRead(courseSections)
+                notifyItemChanged(layoutPosition)
 
-                val count = courseDataHandler.getUnreadCount(this@MyCoursesFragment.courses[position].id)
-                unread_count.text = DecimalFormat.getIntegerInstance().format(count.toLong())
-                unread_count.visibility = if (count == 0) View.INVISIBLE else View.VISIBLE
                 Toast.makeText(activity, "Marked all as read", Toast.LENGTH_SHORT).show()
             }
 
@@ -424,7 +422,7 @@ class MyCoursesFragment : Fragment() {
                     observer = Observer { option: MoreOptionsFragment.Option? ->
                         when (option?.getId()) {
                             0 -> confirmDownloadCourse()
-                            1 -> markAllAsRead(layoutPosition)
+                            1 -> markAllAsRead()
                             2 -> setFavoriteStatus(layoutPosition, !isFavorite)
                         }
                         moreOptionsViewModel.selection.removeObservers((context as AppCompatActivity))


### PR DESCRIPTION
The UI is updated when a course is marked as read or a module is marked as unread.

Fixes #266