### PR TITLE
Update Moodle instance URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Dates are in `yyyy-mm-dd`.
 ### Added
 
 ### Changed
+* Moodle instance URL
 
 ### Fixed
 * Unparsed HTML entities in Discussion notifications

--- a/app/src/main/java/crux/bphc/cms/app/Constants.java
+++ b/app/src/main/java/crux/bphc/cms/app/Constants.java
@@ -12,7 +12,7 @@ public class Constants {
     public static final String COURSE_PARCEL_INTENT_KEY = "course_parcel";
     public static final String WEBSITE_URL = "https://crux-bphc.github.io/";
 
-    public static final String API_URL = "https://td.bits-hyderabad.ac.in/moodle/";
+    public static final String API_URL = "https://cms.bits-hyderabad.ac.in";
     public static final String SSO_LOGIN_URL = API_URL +
             "/admin/tool/mobile/launch.php?service=moodle_mobile_app&passport=%s&urlscheme=%s&oauthsso=1";
     public static final String COURSE_URL = API_URL + "/course/view.php";


### PR DESCRIPTION
Moodle was shifted to the cloud. It now sits at
https://cms.bits-hyderabad.ac.in