### PR TITLE
Opt out of Scoped Storage

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:icon="@mipmap/ic_blue_launcher_app_icon"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:requestLegacyExternalStorage="true">
 
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_icon"


### PR DESCRIPTION
Scoped Storage is a shitshow and reduces the functioanlity provided by
the app. It is impossible to list files created by your own app after
reinstalls. The alternative to opting out would be to move to the
external app directory. However, this means users won't be able to find
their files easily through a file manager.

Let's hope Google brings an alternative for our usecase.

Also: This patch also cleans up FileManager