### PR TITLE
Move intent resolution to onCreate

### DIFF
--- a/app/src/main/java/crux/bphc/cms/activities/CourseDetailActivity.kt
+++ b/app/src/main/java/crux/bphc/cms/activities/CourseDetailActivity.kt
@@ -37,12 +37,11 @@ class CourseDetailActivity : AppCompatActivity() {
 
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         supportActionBar?.setHomeButtonEnabled(true)
+
+        resolveIntent()
     }
 
-    override fun onResume() {
-        super.onResume()
-
-        val intent = intent
+    private fun resolveIntent() {
         val contextUrl = intent.getStringExtra(INTENT_CONTEXT_URL_KEY) ?: ""
         var courseId = intent.getIntExtra(INTENT_COURSE_ID_KEY, -1)
         val customDataStr = intent.getStringExtra(INTENT_CUSTOM_DATA_KEY) ?: ""

--- a/app/src/main/java/crux/bphc/cms/activities/MainActivity.kt
+++ b/app/src/main/java/crux/bphc/cms/activities/MainActivity.kt
@@ -98,12 +98,8 @@ class MainActivity : AppCompatActivity() {
                     Toast.LENGTH_SHORT,
                 ).show()
             }
-
         }
-    }
 
-    override fun onStart() {
-        super.onStart()
         resolveIntent()
         resolveModuleLinkShare()
     }


### PR DESCRIPTION
This prevents from the same intent being resolved each time the user
comes back to the app.