### PR TITLE
Fix: Searching for courses yields no results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Dates are in `yyyy-mm-dd`.
 
 ### Fixed
 * Downloaded files were corrupt
+* Could not search for courses in main page
 
 ## Version 1.8.1 (verCode 1080100), 2020-01-13
 ### Fixed

--- a/app/src/main/java/crux/bphc/cms/fragments/MyCoursesFragment.kt
+++ b/app/src/main/java/crux/bphc/cms/fragments/MyCoursesFragment.kt
@@ -331,7 +331,7 @@ class MyCoursesFragment : Fragment() {
             var filteredCourses: MutableList<Course> = ArrayList()
             if (courseName.isNotEmpty()) {
                 for (course in courseList) {
-                    if (course.fullName.toLowerCase(Locale.ROOT).contains(courseName)) {
+                    if (course.shortName.toLowerCase(Locale.ROOT).contains(courseName)) {
                         filteredCourses.add(course)
                     }
                 }

--- a/app/src/main/java/crux/bphc/cms/models/course/Course.kt
+++ b/app/src/main/java/crux/bphc/cms/models/course/Course.kt
@@ -15,12 +15,16 @@ import java.util.regex.Pattern
 open class Course(
         @PrimaryKey @SerializedName("id") var id: Int = 0,
         shortName: String = "",
-        var fullName: String = "",
+        fullName: String = "",
         var isFavorite: Boolean = false,
 ) : RealmObject() {
 
     @SerializedName("shortname")
     var shortName = shortName
+        get() = HtmlCompat.fromHtml(field, HtmlCompat.FROM_HTML_MODE_COMPACT).toString().trim()
+
+    @SerializedName("fullname")
+    var fullName = fullName
         get() = HtmlCompat.fromHtml(field, HtmlCompat.FROM_HTML_MODE_COMPACT).toString().trim()
 
     @Ignore private var _courseName: Array<String>? = null


### PR DESCRIPTION
`fullname` property in the API response was not being handled properly.
Considering the entirety of MyCoursesFragment uses `shortname`,
including in the actual course name, we should search `shortname` instead
of `fullname`.