### PR TITLE
Fix: Crash on downloading attachments after network sync of discussion

### DIFF
--- a/app/src/main/java/crux/bphc/cms/fragments/DiscussionFragment.kt
+++ b/app/src/main/java/crux/bphc/cms/fragments/DiscussionFragment.kt
@@ -94,7 +94,6 @@ class DiscussionFragment : Fragment() {
         val discussion = realm.where(Discussion::class.java).equalTo("discussionId", discussionId)
                 .findFirst()
         if (discussion != null) {
-            this.discussion = discussion
             setDiscussion(discussion)
         } else {
             refreshContent(forumId, discussionId)
@@ -103,6 +102,7 @@ class DiscussionFragment : Fragment() {
 
     @MainThread
     private fun setDiscussion(discussion: Discussion) {
+        this.discussion = discussion
         content.visibility = View.VISIBLE
         empty.visibility = View.GONE
         swipeRefreshLayout.isRefreshing = false
@@ -236,7 +236,7 @@ class DiscussionFragment : Fragment() {
         }
 
         val attachments = discussion.attachments
-        val attachment = attachments.where().equalTo("fileName", filename).findFirst()
+        val attachment = attachments.firstOrNull { it.fileName == filename }
         attachment?.let { fileManager.openDiscussionAttachment(it) }
 
     }


### PR DESCRIPTION
Trying to download an attachment immediately after the discussion loads
after a network sync crashes the app (for example downloading an
attachment in discussion after pressing on a notification).

Remove method calls to managed Realm objects since there is no guarantee
that the objects are managed by Realm.

Close #308