### PR TITLE
Remove NDK cache steps from Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,20 +12,6 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - name: Prepare NDK dir for caching
-      run: |
-        sudo mkdir -p /usr/local/lib/android/sdk/ndk
-        sudo chmod -R 777 /usr/local/lib/android/sdk/ndk
-        sudo chown -R $USER:$USER /usr/local/lib/android/sdk/ndk
-    - name: NDK Cache
-      id: ndk-cache
-      uses: actions/cache@v2
-      with:
-        path: /usr/local/lib/android/sdk/ndk
-        key: ndk-cache-21.0.6113669-v2
-    - name: Install NDK
-      if: steps.ndk-cache.outputs.cache-hit != 'true'
-      run: echo "y" | sudo /usr/local/lib/android/sdk/tools/bin/sdkmanager --install "ndk;21.0.6113669" --sdk_root=${ANDROID_SDK_ROOT}
     - name: Assemble APKs
       run: bash ./gradlew assemble --stacktrace
     - name: Create Debug APK artifiact


### PR DESCRIPTION
We don't use the NDK in the app. Installing the NDK, even if it's from a
cache just slows things down.