### PR TITLE
Improve module read/unread logic

### DIFF
--- a/app/src/main/java/crux/bphc/cms/fragments/CourseContentFragment.kt
+++ b/app/src/main/java/crux/bphc/cms/fragments/CourseContentFragment.kt
@@ -172,7 +172,7 @@ class CourseContentFragment : Fragment() {
                         }
                         2 -> fileManager.shareModuleContent(content!!)
                         3 -> {
-                            courseDataHandler.markModuleAsReadOrUnread(module, true)
+                            courseDataHandler.markModuleAsUnread(module);
                             adapter.notifyItemChanged(position)
                         }
                         4 -> PropertiesAlertDialog(activity, content).show()
@@ -201,7 +201,7 @@ class CourseContentFragment : Fragment() {
                         }
                         1 -> shareModuleLinks(module)
                         2 -> {
-                            courseDataHandler.markModuleAsReadOrUnread(module, true)
+                            courseDataHandler.markModuleAsUnread(module);
                             adapter.notifyItemChanged(position)
                         }
                         3 -> if (content != null && activity != null) {
@@ -222,7 +222,7 @@ class CourseContentFragment : Fragment() {
                 moreOptionsFragment.show(requireActivity().supportFragmentManager,
                         moreOptionsFragment.tag)
                 moreOptionsViewModel.selection.observe(activity, observer)
-                courseDataHandler.markModuleAsReadOrUnread(module, false)
+                courseDataHandler.markModuleAsRead(module);
                 adapter.notifyItemChanged(position)
             }
             true
@@ -280,7 +280,7 @@ class CourseContentFragment : Fragment() {
                     Utils.openURLInBrowser(activity, module.url)
                 }
             }
-            courseDataHandler.markModuleAsReadOrUnread(module, false)
+            courseDataHandler.markModuleAsRead(module);
             true
         }
     }
@@ -362,7 +362,7 @@ class CourseContentFragment : Fragment() {
                         val newDiscussions = courseDataHandler
                                 .setForumDiscussions(module.instance, discussions)
                         if (newDiscussions.size > 0) {
-                            courseDataHandler.markModuleAsReadOrUnread(module, true)
+                            courseDataHandler.markModuleAsUnread(module);
                         }
                     }
                 }
@@ -387,7 +387,7 @@ class CourseContentFragment : Fragment() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == R.id.mark_all_as_read) {
-            courseDataHandler.markAllAsRead(courseSections)
+            courseDataHandler.markCourseAsRead(courseId)
             courseSections = courseDataHandler.getCourseData(courseId)
             setCourseContentsOnAdapter()
             Toast.makeText(activity, "Marked all as read", Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/crux/bphc/cms/fragments/MyCoursesFragment.kt
+++ b/app/src/main/java/crux/bphc/cms/fragments/MyCoursesFragment.kt
@@ -81,13 +81,9 @@ class MyCoursesFragment : Fragment() {
                 CoroutineScope(Dispatchers.Default).launch {
                     val realm = Realm.getDefaultInstance()
                     val courseDataHandler = CourseDataHandler(realm)
-
-                    for (course in courses) {
-                        val sections = courseDataHandler.getCourseData(course.id)
-                        courseDataHandler.markAllAsRead(sections)
-                    }
-
+                    courseDataHandler.markAllAsRead();
                     realm.close()
+
                     CoroutineScope(Dispatchers.Main).launch {
                         Toast.makeText(requireActivity(), "Marked all as read", Toast.LENGTH_SHORT).show()
                         mAdapter.courses = this@MyCoursesFragment.courseDataHandler.courseList
@@ -369,12 +365,9 @@ class MyCoursesFragment : Fragment() {
                         .show()
             }
 
-            fun markAllAsRead() {
+            fun markCourseAsRead() {
                 val courseId = courses[layoutPosition].id
-                val courseSections: List<CourseSection>
-
-                courseSections = courseDataHandler.getCourseData(courseId)
-                courseDataHandler.markAllAsRead(courseSections)
+                courseDataHandler.markCourseAsRead(courseId)
                 notifyItemChanged(layoutPosition)
 
                 Toast.makeText(activity, "Marked all as read", Toast.LENGTH_SHORT).show()
@@ -416,7 +409,7 @@ class MyCoursesFragment : Fragment() {
                         if (it == null) return@observe;
                         when (it.id) {
                             0 -> confirmDownloadCourse()
-                            1 -> markAllAsRead()
+                            1 -> markCourseAsRead()
                             2 -> setFavoriteStatus(layoutPosition, !isFavorite)
                         }
                         moreOptionsViewModel.selection.removeObservers(requireActivity())


### PR DESCRIPTION
Use batch updates to mark items as read/unread instead of individual
updating database. This makes the 'Mark all as read' action from
MyCoursesFragment near instantaneous when you everything in every
course as unread.

Also refactored 'markModuleAsReadOrUnread' method.