### PR TITLE
Use sorted courses list for download course

### DIFF
--- a/app/src/main/java/crux/bphc/cms/fragments/MyCoursesFragment.kt
+++ b/app/src/main/java/crux/bphc/cms/fragments/MyCoursesFragment.kt
@@ -349,7 +349,7 @@ class MyCoursesFragment : Fragment() {
                         .setPositiveButton("Yes") { _: DialogInterface?, _: Int ->
                             if (downloadClickListener != null) {
                                 val pos = layoutPosition
-                                if (!downloadClickListener!!.onClick(this@MyCoursesFragment.courses[pos], pos)) {
+                                if (!downloadClickListener!!.onClick(courses[pos], pos)) {
                                     Toast.makeText(activity, "Download already in progress",
                                             Toast.LENGTH_SHORT).show()
                                 }


### PR DESCRIPTION
Changed the download course function to use the courses list of the Adapter since it is updated after sorting, alphabetically and according to favourite status.

Fixes #331