### PR TITLE
Fix deletion snackbar visibility issue.

### DIFF
--- a/app/src/main/java/crux/bphc/cms/fragments/FilesFragment.kt
+++ b/app/src/main/java/crux/bphc/cms/fragments/FilesFragment.kt
@@ -21,6 +21,7 @@ import crux.bphc.cms.core.getFormattedFileSize
 import crux.bphc.cms.databinding.DownloadsFragmentBinding
 import crux.bphc.cms.models.Download
 import crux.bphc.cms.models.SingleLiveEvent
+import crux.bphc.cms.models.UserAccount
 import crux.bphc.cms.utils.FileUtils
 import crux.bphc.cms.viewmodels.FilesViewModel
 import kotlinx.android.synthetic.main.fragment_my_courses.*
@@ -111,7 +112,17 @@ class FilesFragment : Fragment() {
 
     private val deletedMessageObserver = Observer<SingleLiveEvent<Boolean>> { deletedSuccessfully ->
         deletedSuccessfully.getContentIfNotHandled()?.let { deleted ->
-            Snackbar.make(binding.downloadsCoordinator, getString(if (deleted) R.string.delete_file_success else R.string.delete_file_failed), Snackbar.LENGTH_SHORT).show()
+            val snackbar = Snackbar.make(binding.downloadsCoordinator, getString(if (deleted) R.string.delete_file_success else R.string.delete_file_failed), Snackbar.LENGTH_SHORT)
+            if(UserAccount.isDarkModeEnabled){
+                snackbar.setTextColor(resources.getColor(R.color.text_primary_dark))
+                snackbar.setBackgroundTint(resources.getColor(R.color.activityBackgroundDark))
+            }
+            else {
+                snackbar.setTextColor(resources.getColor(R.color.text_primary_light))
+                snackbar.setBackgroundTint(resources.getColor(R.color.activityBackgroundLight))
+            }
+
+            snackbar.show()
         }
     }
 


### PR DESCRIPTION
Snackbar message is now clearly visible on deletion.

Light mode:
![491efce4-547c-4306-9bec-f9544e87fd29](https://user-images.githubusercontent.com/75108809/148401196-12093c46-53eb-4f4d-8231-fd066adbdc24.jpg)

Dark mode:
![54334408-d9e6-497b-86e1-7f779febf047](https://user-images.githubusercontent.com/75108809/148401208-ea39c038-a01a-4a7f-a530-872bd229e2e3.jpg)

