### PR TITLE
Bump app version to 1.11 (1110000) in CHANGELOG.md and Gradle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,17 @@ Dates are in `yyyy-mm-dd`.
 
 ### Fixed
 
-## Version 1.10 (verCode 1100000), 2024-02-25
+## Version 1.11 (verCode 1110000), 2024-02-25
+### Added
+* An icon that displays number of unread notifications
+* A new screen to view notifications
+
+### Changed
+
+### Fixed
+* HTML Text not rendering properly
+
+## Version 1.10 (verCode 1100000), 2023-05-23
 ### Added
 * Mark All as Read marks notifications as read on website.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,8 +28,8 @@ android {
         applicationId "crux.bphc.cms"
         minSdkVersion 24
         targetSdkVersion 33
-        versionCode 1100000
-        versionName "1.10"
+        versionCode 1110000
+        versionName "1.11"
         vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         // Inject the commit hash of HEAD into BuildConfig


### PR DESCRIPTION
Date for Version 1.10 in CHANGELOG has been updated to 2023-05-23 as 1.10 was released to the Playstore on that date